### PR TITLE
Add helpers for throwing closures when mapping sequences

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/Future+Collection.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Collection.swift
@@ -86,4 +86,48 @@ extension EventLoopFuture where Value: Sequence {
             }
         }
     }
+
+    /// Calls a closure on each element in the sequence that is wrapped by an `EventLoopFuture`.
+    ///
+    ///     let collection = eventLoop.future([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    ///     let times2 = collection.flatMapEachThrowing { int in
+    ///         guard int < 10 else { throw RangeError.oops }
+    ///         return int * 2
+    ///     }
+    ///     // times2: EventLoopFuture([2, 4, 6, 8, 10, 12, 14, 16, 18])
+    ///
+    /// If your callback function throws, the returned `EventLoopFuture` will error.
+    ///
+    /// - parameters:
+    ///   - transform: The closure that each element in the sequence is passed into.
+    ///   - element: The element from the sequence that you can operate on.
+    /// - returns: A new `EventLoopFuture` that wraps that sequence of transformed elements.
+    public func flatMapEachThrowing<Result>(_ transform: @escaping (_ element: Value.Element) throws -> Result) -> EventLoopFuture<[Result]> {
+        return self.flatMapThrowing { sequence -> [Result] in
+            return try sequence.map(transform)
+        }
+    }
+
+    /// Calls a closure, which returns an `Optional`, on each element in the sequence that is wrapped by an `EventLoopFuture`.
+    ///
+    ///     let collection = eventLoop.future(["one", "2", "3", "4", "five", "^", "7"])
+    ///     let times2 = collection.mapEachCompact { int in
+    ///         return Int(int)
+    ///     }
+    ///     // times2: EventLoopFuture([2, 3, 4, 7])
+    ///
+    /// If your callback function throws, the returned `EventLoopFuture` will error.
+    ///
+    /// - parameters:
+    ///   - transform: The closure that each element in the sequence is passed into.
+    ///   - element: The element from the sequence that you can operate on.
+    /// - returns: A new `EventLoopFuture` that wraps that sequence of transformed elements.
+    public func flatMapEachCompactThrowing<Result>(
+        _ transform: @escaping (_ element: Value.Element) throws -> Result?
+    ) -> EventLoopFuture<[Result]> {
+        return self.flatMapThrowing { sequence -> [Result] in
+            return try sequence.compactMap(transform)
+        }
+    }
+    
 }

--- a/Tests/AsyncKitTests/Future+CollectionTests.swift
+++ b/Tests/AsyncKitTests/Future+CollectionTests.swift
@@ -34,6 +34,31 @@ final class FutureCollectionTests: XCTestCase {
         try XCTAssertEqual(times2.wait(), [2, 3, 4, 7])
     }
     
+    func testFlatMapEachThrowing() throws {
+        struct SillyRangeError: Error {}
+        let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
+        let times2 = collection.flatMapEachThrowing { int -> Int in
+            guard int < 8 else { throw SillyRangeError() }
+            return int * 2
+        }
+        
+        XCTAssertThrowsError(try times2.wait())
+    }
+    
+    func testFlatMapEachCompactThrowing() throws {
+        struct SillyRangeError: Error {}
+        let collection = self.eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
+        let times2 = collection.flatMapEachCompactThrowing { str -> Int? in Int(str) }
+        let times2Badly = collection.flatMapEachCompactThrowing { str -> Int? in
+            guard let result = Int(str) else { return nil }
+            guard result < 4 else { throw SillyRangeError() }
+            return result
+        }
+        
+        try XCTAssertEqual(times2.wait(), [2, 3, 4, 7])
+        XCTAssertThrowsError(try times2Badly.wait())
+    }
+
     /// This TestCases EventLoopGroup
     var group: EventLoopGroup!
     


### PR DESCRIPTION
Adds:

- `flatMapEachThrowing()` - identical to `mapEach()`, except that the body may throw an error. Any error thrown, regardless of which element of the sequence it was, fails the entire future.

- `flatMapEachCompactThrowing()` - identical to `mapEachCompact()` except with throwing bodies.

- Unit tests for both.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`
