### PR TITLE
Add methods to EventLoopFutureQueue for queueing sequences

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue+Sequence.swift
+++ b/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue+Sequence.swift
@@ -30,6 +30,8 @@ extension EventLoopFutureQueue {
         }
     }
     
+    /// Same as `append(each:_:)` above, but assumes all futures return `Void`
+    /// and returns a `Void` future instead of a result array.
     public func append<S: Sequence>(each seq: S, _ generator: @escaping (S.Element) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
         return seq.reduce(self.append(self.eventLoop.future())) { self.append(generator($1)) }
     }

--- a/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue+Sequence.swift
+++ b/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue+Sequence.swift
@@ -1,0 +1,38 @@
+import NIO
+
+extension EventLoopFutureQueue {
+    
+    /// For each element of the provided collection, invoke the given generator
+    /// and queue the returned future. Return a future whose value is an array
+    /// containing the result of each generated future in the same order as the
+    /// original sequence. The resulting array is intended to have semantics
+    /// substantially similar to those provided by `EventLoop.flatten(_:on:)`.
+    public func append<S: Sequence, Value>(each seq: S, _ generator: @escaping (S.Element) -> EventLoopFuture<Value>) -> EventLoopFuture<[Value]> {
+
+        // For each element in the sequence, obtain a generated future, add the result of that future to the result
+        // array, map the future to `Void`, and append the result to this queue. Left with the final future in the
+        // chain (representing the result of the final element in the sequence) via `reduce()`, append to the queue
+        // a last future whose value is the results array, which should now be complete. The in-order and immediate-
+        // halt-on-fail guarantees of the queue itself negate any need to maintain a separate `Promise` or use
+        // `enumerated()` to ensure consistency of the results array (see `EventLoopFuture.whenAllComplete(_:on:)` for
+        // more information).
+        var count: Int = 0 // used for debugging assertions
+        var results: [Value] = []
+        results.reserveCapacity(seq.underestimatedCount)
+        
+        return seq.reduce(self.append(self.eventLoop.future())) { // if the sequence is empty, the initial future will do nothing
+            assert({ count += 1; return true }())
+            return self.append(generator($1).map { results.append($0) })
+        }.map {
+            // TODO: Should this future be appended rather than directly mapped?
+            assert(results.count == count, "Sequence completed, but we didn't get all the results, or got too many - EventLoopFutureQueue is broken.")
+            return results
+        }
+    }
+    
+    public func append<S: Sequence>(each seq: S, _ generator: @escaping (S.Element) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+        return seq.reduce(self.append(self.eventLoop.future())) { self.append(generator($1)) }
+    }
+
+}
+

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -121,6 +121,27 @@ final class EventLoopFutureQueueTests: XCTestCase {
             }
         }
     }
+    
+    func testSimpleSequence() throws {
+        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+        let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        
+        let all = queue.append(each: values) { self.eventLoop.slowFuture($0, sleeping: 1) }
+        
+        try XCTAssertNoThrow(queue.future.wait())
+        try XCTAssertEqual(all.wait(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    }
+    
+    func testVoidReturnSequence() throws {
+        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+        let values = 99..<135
+        var output: [Int] = []
+        let all = queue.append(each: values) { v in self.eventLoop.slowFuture((), sleeping: 0).map { output.append(v) } }
+
+        try XCTAssertNoThrow(queue.future.wait())
+        try XCTAssertNoThrow(all.wait())
+        XCTAssertEqual(Array(values), output)
+    }
 
 
     /// This TestCases EventLoopGroup


### PR DESCRIPTION
These methods correspond to the `flatten(on:)` methods on `EventLoopGroup` and serve much the same purpose, while leveraging the strict ordering guarantees of the queue.

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`
