### PR TITLE
Add sugar for starting a future chain with a throwing closure.

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/Future+Throwing.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Throwing.swift
@@ -1,0 +1,36 @@
+import NIO
+
+extension EventLoopGroup {
+    
+    /// An alternate name for this would be `future(catching:)`, but with that
+    /// name, trailing closure syntax just looks like `el.future { ... }`, which
+    /// does not indicate to readers of the code that it is the error-capturing
+    /// version. Since such an indication is highly desirable, a slightly less
+    /// idiomatic name is used instead.
+    ///
+    /// This method replaces this code:
+    ///
+    /// ```swift
+    /// return something.eventLoop.future().flatMapThrowing {
+    /// ```
+    ///
+    /// With this code:
+    ///
+    /// ```swift
+    /// return something.eventLoop.tryFuture {
+    /// ```
+    ///
+    /// That's pretty much it. It's sugar.
+    ///
+    /// - Parameter work: The potentially throwing closure to execute as a
+    ///   future. If the closure throws, a failed future is returned.
+    public func tryFuture<T>(_ work: () throws -> T) -> EventLoopFuture<T> {
+        do {
+            return self.future(try work())
+        } catch {
+            return self.future(error: error)
+        }
+    }
+
+}
+

--- a/Tests/AsyncKitTests/FutureExtensionsTests.swift
+++ b/Tests/AsyncKitTests/FutureExtensionsTests.swift
@@ -12,6 +12,16 @@ final class FutureExtensionsTests: XCTestCase {
         XCTAssertThrowsError(try guardedFuture2.wait())
     }
     
+    func testTryThrowing() {
+        let future1: EventLoopFuture<String> = eventLoop.tryFuture { return "Hello" }
+        let future2: EventLoopFuture<String> = eventLoop.tryFuture { throw TestError.notEqualTo1 }
+        var value: String = ""
+        
+        try XCTAssertNoThrow(value = future1.wait())
+        XCTAssertEqual(value, "Hello")
+        try XCTAssertThrowsError(future2.wait())
+    }
+    
     /// This TestCases EventLoopGroup
     var group: EventLoopGroup!
     


### PR DESCRIPTION
Very simple, includes a test anyway.

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`
