### PR TITLE
Quick fix for thread safety issue in EventLoopFutureQueue

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
+++ b/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
@@ -29,9 +29,6 @@ public final class EventLoopFutureQueue {
     /// The event loop that all the futures's completions are handled on.
     public let eventLoop: EventLoop
 
-    /// The final result of all the futures that have been run up to the current point.
-    public var future: EventLoopFuture<Void> { self.current }
-
     private var current: EventLoopFuture<Void>
 
     /// Create a new `EventLoopFutureQueue` on a given event loop.

--- a/Tests/AsyncKitTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncKitTests/ConnectionPoolTests.swift
@@ -246,10 +246,10 @@ private struct ErrorDatabase: ConnectionPoolSource {
 }
 
 private final class FooDatabase: ConnectionPoolSource {
-    var connectionsCreated: Atomic<Int>
+    var connectionsCreated: NIOAtomic<Int>
 
     init() {
-        self.connectionsCreated = .init(value: 0)
+        self.connectionsCreated = .makeAtomic(value: 0)
     }
     
     func makeConnection(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<FooConnection> {

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -39,8 +39,6 @@ final class EventLoopFutureQueueTests: XCTestCase {
             }
         })
 
-        try XCTAssertNoThrow(queue.future.wait())
-
         try XCTAssertEqual(one.wait(), 1)
         try XCTAssertEqual(two.wait(), 2)
         try XCTAssertEqual(three.wait(), 3)
@@ -60,8 +58,6 @@ final class EventLoopFutureQueueTests: XCTestCase {
         let three = queue.append(self.eventLoop.slowFuture(3, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
         let four = queue.append(self.eventLoop.slowFuture(4, sleeping: 4).map { num in lock.withLockVoid { numbers.append(num) } })
         let five = queue.append(self.eventLoop.slowFuture(5, sleeping: 1).map { num in lock.withLockVoid { numbers.append(num) } })
-
-        try XCTAssertNoThrow(queue.future.wait())
 
         try XCTAssertNoThrow(one.wait())
         try XCTAssertNoThrow(two.wait())
@@ -127,8 +123,7 @@ final class EventLoopFutureQueueTests: XCTestCase {
         let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         
         let all = queue.append(each: values) { self.eventLoop.slowFuture($0, sleeping: 1) }
-        
-        try XCTAssertNoThrow(queue.future.wait())
+
         try XCTAssertEqual(all.wait(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     }
     
@@ -138,7 +133,6 @@ final class EventLoopFutureQueueTests: XCTestCase {
         var output: [Int] = []
         let all = queue.append(each: values) { v in self.eventLoop.slowFuture((), sleeping: 0).map { output.append(v) } }
 
-        try XCTAssertNoThrow(queue.future.wait())
         try XCTAssertNoThrow(all.wait())
         XCTAssertEqual(Array(values), output)
     }


### PR DESCRIPTION
Wraps `append(onPrevious:generator:)` in an `EventLoop.flatSubmit()` invocation to serve as a stopgap fix against thread-unsafe behavior in the method body. Change was authored by @calebkleveter. Thanks to @Lukasa for the heads-up on the problem.

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`
