### PR TITLE
Don't assert when a future in a queued sequence fails

### DIFF
--- a/Tests/AsyncKitTests/XCTestManifests.swift
+++ b/Tests/AsyncKitTests/XCTestManifests.swift
@@ -34,6 +34,10 @@ extension EventLoopFutureQueueTests {
         ("testContinueOnFail", testContinueOnFail),
         ("testContinueOnSucceed", testContinueOnSucceed),
         ("testQueue", testQueue),
+        ("testSequenceWithFailure", testSequenceWithFailure),
+        ("testSimpleSequence", testSimpleSequence),
+        ("testVoidReturnSequence", testVoidReturnSequence),
+        ("testVoidSequenceWithFailure", testVoidSequenceWithFailure),
     ]
 }
 
@@ -78,6 +82,7 @@ extension FutureExtensionsTests {
     // to regenerate.
     static let __allTests__FutureExtensionsTests = [
         ("testGuard", testGuard),
+        ("testTryThrowing", testTryThrowing),
     ]
 }
 


### PR DESCRIPTION
Currently, if one of the futures appended by `EventLoopFutureQueue.append(each:generator:)` fails, we fire an incorrect assertion instead of failing the chain correctly. This PR fixes the issue and adds unit tests.