### PR TITLE
Remove checklist item for regenerating LinuxMain.swift

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,3 @@
 - [ ] There are no breaking changes to public API.
 - [ ] New test cases have been added where appropriate.
 - [ ] All new code has been commented with doc blocks `///`.
-- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`


### PR DESCRIPTION
Since everything now uses `--enable-test-discovery` regenerating the LinuxMain and test manifests is no longer needed for new PRs

<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`
