### PR TITLE
Conform EventLoopFutureQueue.ContinueError to CustomStringConvertible

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
+++ b/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
@@ -28,7 +28,7 @@ public final class EventLoopFutureQueue {
         /// A textual representation of the error.
         ///
         /// In the case of a `.previousError` case, the result will be flattened to a single `.previousError(error)`,
-        /// instead of nesting them so deep that it's too large to fit in a single Slack message.
+        /// instead of being nested _n_ cases deep `.previousError(.previousError(.previousError(error)))`.
         public var description: String {
             switch self {
             case .previousSuccess: return "previousSuccess"

--- a/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
+++ b/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
@@ -17,13 +17,31 @@ public final class EventLoopFutureQueue {
     }
 
     /// Errors that get propogated based on a future's completion status and the next appended closure's continuation condition.
-    public enum ContinueError: Error {
+    public enum ContinueError: Error, CustomStringConvertible {
 
         /// A previous future failed with an error, which we don't desire.
         case previousError(Error)
 
         /// A previous future succeeded, which we don't desire.
         case previousSuccess
+
+        /// A textual representation of the error.
+        ///
+        /// In the case of a `.previousError` case, the result will be flattened to a single `.previousError(error)`,
+        /// instead of nesting them so deep that it's too large to fit in a single Slack message.
+        public var description: String {
+            switch self {
+            case .previousSuccess: return "previousSuccess"
+            case let .previousError(error):
+                if let sub = error as? ContinueError {
+                    return sub.description
+                } else if let convertible = error as? CustomStringConvertible {
+                    return "previousError(\(convertible.description))"
+                } else {
+                    return "previousError(\(error))"
+                }
+            }
+        }
     }
 
     /// The event loop that all the futures's completions are handled on.

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -179,6 +179,15 @@ final class EventLoopFutureQueueTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
+    func testContinueErrorPreviousErrorDescription() throws {
+        let error = EventLoopFutureQueue.ContinueError.previousError(
+            EventLoopFutureQueue.ContinueError.previousError(
+                EventLoopFutureQueue.ContinueError.previousError(Failure.nope)
+            )
+        )
+
+        XCTAssertEqual(error.description, "previousError(nope)")
+    }
 
     /// This TestCases EventLoopGroup
     var group: EventLoopGroup!


### PR DESCRIPTION
The `EventLoopFutureQueue.ContinueError.previousError` case will now be flattened when printed.