### PR TITLE
New and better-behaved shutdown methods for `EventLoopGroupConnectionPool`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test Matrix
-on: ['pull_request', 'push']
+on:
+  pull_request: 
+  push: { branches: [ master ] }
 jobs:
   tests-linux:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Convert data to LCOV format and save location
         run: |
           export b=$(swift build --show-bin-path) && llvm-cov export -format lcov \
-            -instr-profile=$b/codecov/default.profdata $b/async-kitPackageTests.xctest \
-            >$(swift test --show-codecov-path).lcov
+            -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
+            $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
           echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
       - name: Send to codecov.io
         uses: codecov/codecov-action@v1.0.7
@@ -51,4 +51,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --enable-test-discovery --sanitize=thread --enable-code-coverage
+      - name: Convert data to LCOV format and save location
+         run: |
+           export b=$(swift build --show-bin-path) && xcrun llvm-cov export -format lcov \
+            -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
+            $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
+          echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
+      - name: Send to codecov.io
+         uses: codecov/codecov-action@v1.0.7
+         with:
+           file: ${{ env.CODECOV_FILE }}
+           flags: unittests
+           env_vars: SWIFT_RUNNER
+           fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,9 @@ jobs:
           $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
           echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
       - name: Send to codecov.io
-         uses: codecov/codecov-action@v1.0.7
-         with:
-           file: ${{ env.CODECOV_FILE }}
-           flags: unittests
-           env_vars: SWIFT_RUNNER
-           fail_ci_if_error: true
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          file: ${{ env.CODECOV_FILE }}
+          flags: unittests
+          env_vars: SWIFT_RUNNER
+          fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,8 @@ jobs:
         run: |
           export b=$(swift build --show-bin-path) && xcrun llvm-cov export -format lcov \
           -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
-          $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
+          $b/async-kitPackageTests.xctest/Contents/MacOS/async-kitPackageTests \
+          >$(swift test --show-codecov-path).lcov
           echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
       - name: Send to codecov.io
         uses: codecov/codecov-action@v1.0.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Convert data to LCOV format and save location
         run: |
           export b=$(swift build --show-bin-path) && llvm-cov export -format lcov \
-            -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
-            $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
+          -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
+          $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
           echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
       - name: Send to codecov.io
         uses: codecov/codecov-action@v1.0.7
@@ -55,9 +55,9 @@ jobs:
       - name: Convert data to LCOV format and save location
          run: |
            export b=$(swift build --show-bin-path) && xcrun llvm-cov export -format lcov \
-            -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
-            $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
-          echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
+           -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
+           $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
+           echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
       - name: Send to codecov.io
          uses: codecov/codecov-action@v1.0.7
          with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,52 @@
-name: test
-on:
-- pull_request
-- push
+name: Test Matrix
+on: ['pull_request', 'push']
 jobs:
-  xenial:
-    container:
-      image: vapor/swift:5.2-xenial
+  tests-linux:
+    strategy:
+      matrix:
+        runner: ['swift:5.2-xenial', 'swift:5.2-bionic',
+                 'swiftlang/swift:nightly-5.2-xenial', 'swiftlang/swift:nightly-5.2-bionic',
+                 'swiftlang/swift:nightly-5.3-xenial', 'swiftlang/swift:nightly-5.3-bionic',
+                 'swiftlang/swift:nightly-master-xenial', 'swiftlang/swift:nightly-master-bionic',
+                 'swiftlang/swift:nightly-master-focal',
+                 'swiftlang/swift:nightly-master-centos8', 'swiftlang/swift:nightly-master-amazonlinux2']
+        include:
+          - installcmd: 'apt-get -q update && apt-get -q install -y curl'
+          - { 'runner': 'swiftlang/swift:nightly-master-centos8', 'installcmd': 'true' }
+          - { 'runner': 'swiftlang/swift:nightly-master-amazonlinux2', 'installcmd': 'true' }
+    container: ${{ matrix.runner }}
+    env:
+      SWIFT_RUNNER: ${{ matrix.runner }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-  bionic:
-    container:
-      image: vapor/swift:5.2-bionic
-    runs-on: ubuntu-latest
+      - name: Install dependencies
+        run: ${{ matrix.installcmd }}
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer and code coverage
+        run: swift test --enable-test-discovery --sanitize=thread --enable-code-coverage
+      - name: Convert data to LCOV format and save location
+        run: |
+          export b=$(swift build --show-bin-path) && llvm-cov export -format lcov \
+            -instr-profile=$b/codecov/default.profdata $b/async-kitPackageTests.xctest \
+            >$(swift test --show-codecov-path).lcov
+          echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
+      - name: Send to codecov.io
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          file: ${{ env.CODECOV_FILE }}
+          flags: unittests
+          env_vars: SWIFT_RUNNER
+          fail_ci_if_error: true
+  tests-macos:
+    runs-on: macos-latest
+    env:
+      SWIFT_RUNNER: 'macOS'
     steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --enable-code-coverage --sanitize=thread
-  codecov:
-    container:
-      image: vapor/swift:5.2-bionic
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --enable-code-coverage --sanitize=thread
-    - run: apt update -y; apt install -y curl
-    - name: Convert codecov
-      run: llvm-cov export .build/debug/async-kitPackageTests.xctest -instr-profile=.build/debug/codecov/default.profdata -format lcov > data.lcov
-    - uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: true
+      - name: Select latest available Xcode
+        uses: maxim-lobanov/setup-xcode@1.0
+        with: { 'xcode-version': 'latest' }
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,11 @@ jobs:
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread --enable-code-coverage
       - name: Convert data to LCOV format and save location
-         run: |
-           export b=$(swift build --show-bin-path) && xcrun llvm-cov export -format lcov \
-           -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
-           $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
-           echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
+        run: |
+          export b=$(swift build --show-bin-path) && xcrun llvm-cov export -format lcov \
+          -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
+          $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
+          echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
       - name: Send to codecov.io
          uses: codecov/codecov-action@v1.0.7
          with:

--- a/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
@@ -125,7 +125,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
             return (eventLoop ?? self.eventLoopGroup).future(error: ConnectionPoolError.shutdown)
         }
         return self.pool(for: eventLoop ?? self.eventLoopGroup.next())
-                   .requestConnection(logger: logger ?? self.logger)
+            .requestConnection(logger: logger ?? self.logger)
     }
     
     /// Releases a connection back to the pool. Use with `requestConnection()`.

--- a/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
@@ -277,12 +277,12 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
         
         shutdownGroup.notify(queue: shutdownQueue) {
             switch outcome {
-                case .success:
-                    self.logger.debug("Connection group pool finished shutdown.")
-                    callback(nil)
-                case .failure(let error):
-                    self.logger.error("Connection group pool got shutdown error (and then shut down anyway): \(error)")
-                    callback(error)
+            case .success:
+                self.logger.debug("Connection group pool finished shutdown.")
+                callback(nil)
+            case .failure(let error):
+                self.logger.error("Connection group pool got shutdown error (and then shut down anyway): \(error)")
+                callback(error)
             }
         }
     }

--- a/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
@@ -100,7 +100,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
             return (eventLoop ?? self.eventLoopGroup).future(error: ConnectionPoolError.shutdown)
         }
         return self.pool(for: eventLoop ?? self.eventLoopGroup.next())
-                   .withConnection(logger: logger ?? self.logger, closure)
+           .withConnection(logger: logger ?? self.logger, closure)
     }
     
     /// Requests a pooled connection.

--- a/Sources/AsyncKit/EventLoop/EventLoop+Future.swift
+++ b/Sources/AsyncKit/EventLoop/EventLoop+Future.swift
@@ -29,4 +29,17 @@ extension EventLoopGroup {
     public func future<T>(error: Error) -> EventLoopFuture<T> {
         return self.next().makeFailedFuture(error)
     }
+    
+    /// Creates a new `Future` from the worker's event loop, succeeded or failed based on the input `Result`.
+    ///
+    ///     let a: EventLoopFuture<String> = req.future(.success("hello"))
+    ///     let b: EventLoopFuture<String> = req.future(.failed(Abort(.imATeapot))
+    ///
+    /// - Parameter result: The result that the future will wrap.
+    /// - Returns: The succeeded or failed future.
+    public func future<T>(result: Result<T, Error>) -> EventLoopFuture<T> {
+        let promise: EventLoopPromise<T> = self.next().makePromise()
+        promise.completeWith(result)
+        return promise.futureResult
+    }
 }

--- a/Sources/AsyncKit/EventLoop/EventLoop+Future.swift
+++ b/Sources/AsyncKit/EventLoop/EventLoop+Future.swift
@@ -1,18 +1,18 @@
 import NIO
 
 extension EventLoopGroup {
-    /// Creates a new, succeeded `Future` from the worker's event loop with a `Void` value.
+    /// Creates a new, succeeded `EventLoopFuture` from the worker's event loop with a `Void` value.
     ///
-    ///    let a: Future<Void> = req.future()
+    ///    let a: EventLoopFuture<Void> = req.future()
     ///
     /// - Returns: The succeeded future.
     public func future() -> EventLoopFuture<Void> {
         return self.next().makeSucceededFuture(())
     }
     
-    /// Creates a new, succeeded `Future` from the worker's event loop.
+    /// Creates a new, succeeded `EventLoopFuture` from the worker's event loop.
     ///
-    ///    let a: Future<String> = req.future("hello")
+    ///    let a: EventLoopFuture<String> = req.future("hello")
     ///
     /// - Parameter value: The value that the future will wrap.
     /// - Returns: The succeeded future.
@@ -20,9 +20,9 @@ extension EventLoopGroup {
         return self.next().makeSucceededFuture(value)
     }
     
-    /// Creates a new, failed `Future` from the worker's event loop.
+    /// Creates a new, failed `EventLoopFuture` from the worker's event loop.
     ///
-    ///    let b: Future<String> = req.future(error: Abort(...))
+    ///    let b: EvenLoopFuture<String> = req.future(error: Abort(...))
     ///
     /// - Parameter error: The error that the future will wrap.
     /// - Returns: The failed future.

--- a/Sources/AsyncKit/EventLoopFuture/FutureExtensions.swift
+++ b/Sources/AsyncKit/EventLoopFuture/FutureExtensions.swift
@@ -28,4 +28,20 @@ public extension EventLoopFuture {
         }
         return promise.futureResult
     }
+
+    // MARK: - flatMapAlways
+    
+    /// When the current `EventLoopFuture` receives any result, run the provided callback, which will provide a new
+    /// `EventLoopFuture`. Essentially combines the behaviors of `.always(_:)` and `.flatMap(file:line:_:)`.
+    ///
+    /// This is useful when some work must be done for both success and failure states, especially work that requires
+    /// temporarily extending the lifetime of one or more objects.
+    func flatMapAlways<NewValue>(
+        file: StaticString = #file, line: UInt = #line,
+        _ callback: @escaping (Result<Value, Error>) -> EventLoopFuture<NewValue>
+    ) -> EventLoopFuture<NewValue> {
+        let promise = self.eventLoop.makePromise(of: NewValue.self, file: file, line: line)
+        self.whenComplete { result in callback(result).cascade(to: promise) }
+        return promise.futureResult
+    }
 }

--- a/Tests/AsyncKitTests/AsyncKitTests.swift
+++ b/Tests/AsyncKitTests/AsyncKitTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AsyncKit
+import Logging
 
 final class AsyncKitTests: XCTestCase {
     func testUniverseSanity() {
@@ -15,18 +16,37 @@ final class AsyncKitTests: XCTestCase {
         return self.group.next()
     }
     
+    /// Ensures logging is set up
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
+    }
+    
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
     
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
     }
 }
+
+func env(_ name: String) -> String? {
+    return ProcessInfo.processInfo.environment[name]
+}
+
+let isLoggingConfigured: Bool = {
+    LoggingSystem.bootstrap { label in
+        var handler = StreamLogHandler.standardOutput(label: label)
+        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .debug
+        return handler
+    }
+    return true
+}()

--- a/Tests/AsyncKitTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncKitTests/ConnectionPoolTests.swift
@@ -226,12 +226,19 @@ final class ConnectionPoolTests: XCTestCase {
 
     var eventLoopGroup: EventLoopGroup!
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 4)
     }
 
-    override func tearDown() {
-        try! self.eventLoopGroup.syncShutdownGracefully()
+    override func tearDownWithError() throws {
+        try self.eventLoopGroup.syncShutdownGracefully()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }
 

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -199,17 +199,22 @@ final class EventLoopFutureQueueTests: XCTestCase {
 
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
 
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }
 

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -53,10 +53,10 @@ final class EventLoopFutureQueueTests: XCTestCase {
         var numbers: [Int] = []
         let lock = Lock()
 
-        let one = queue.append(self.eventLoop.slowFuture(1, sleeping: 2).map { num in lock.withLockVoid { numbers.append(num) } })
+        let one = queue.append(self.eventLoop.slowFuture(1, sleeping: 1).map { num in lock.withLockVoid { numbers.append(num) } })
         let two = queue.append(self.eventLoop.slowFuture(2, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
         let three = queue.append(self.eventLoop.slowFuture(3, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
-        let four = queue.append(self.eventLoop.slowFuture(4, sleeping: 4).map { num in lock.withLockVoid { numbers.append(num) } })
+        let four = queue.append(self.eventLoop.slowFuture(4, sleeping: 1).map { num in lock.withLockVoid { numbers.append(num) } })
         let five = queue.append(self.eventLoop.slowFuture(5, sleeping: 1).map { num in lock.withLockVoid { numbers.append(num) } })
 
         try XCTAssertNoThrow(one.wait())

--- a/Tests/AsyncKitTests/EventLoopGroup+Future.swift
+++ b/Tests/AsyncKitTests/EventLoopGroup+Future.swift
@@ -33,17 +33,21 @@ final class EventLoopGroupFutureTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }
-

--- a/Tests/AsyncKitTests/FlattenTests.swift
+++ b/Tests/AsyncKitTests/FlattenTests.swift
@@ -55,16 +55,21 @@ final class FlattenTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }

--- a/Tests/AsyncKitTests/Future+CollectionTests.swift
+++ b/Tests/AsyncKitTests/Future+CollectionTests.swift
@@ -69,16 +69,21 @@ final class FutureCollectionTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }

--- a/Tests/AsyncKitTests/Future+OptionalTests.swift
+++ b/Tests/AsyncKitTests/Future+OptionalTests.swift
@@ -1,7 +1,7 @@
 import AsyncKit
 import XCTest
 
-public final class FutureOptionalTests: XCTestCase {
+final class FutureOptionalTests: XCTestCase {
     private enum NIOError: Error {
         case testError
     }
@@ -59,17 +59,22 @@ public final class FutureOptionalTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    public override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    public override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
     
     func multiply(_ a: Int, _ b: Int) -> EventLoopFuture<Int> {

--- a/Tests/AsyncKitTests/FutureExtensionsTests.swift
+++ b/Tests/AsyncKitTests/FutureExtensionsTests.swift
@@ -32,17 +32,22 @@ final class FutureExtensionsTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }
 

--- a/Tests/AsyncKitTests/FutureOperatorsTests.swift
+++ b/Tests/AsyncKitTests/FutureOperatorsTests.swift
@@ -143,16 +143,21 @@ final class FutureOperatorTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }

--- a/Tests/AsyncKitTests/TransformTests.swift
+++ b/Tests/AsyncKitTests/TransformTests.swift
@@ -29,16 +29,21 @@ class TransformTests: XCTestCase {
     
     /// Sets up the TestCase for use
     /// and initializes the EventLoopGroup
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
-    
+
     /// Tears down the TestCase and
     /// shuts down the EventLoopGroup
-    override func tearDown() {
-        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
         self.group = nil
-        super.tearDown()
+        try super.tearDownWithError()
+    }
+
+    override class func setUp() {
+        super.setUp()
+        XCTAssertTrue(isLoggingConfigured)
     }
 }


### PR DESCRIPTION
- Soft-deprecate (documentation only, no warnings from the compiler) `EventLoopGroupConnectionPool.shutdown()` for being unnecessarily synchronous (among other things).
- Add `EventLoopGroupConnectionPool.shutdownGracefully(_:)`, modeled loosely after `EventLoopGroup.shutdownGracefully(queue:_:)`. Shutdown takes place asynchronously, and a callback is invoked on a "safe" Dispatch queue to notify of completion and any errors.
- Add `EventLoopGroupConnectionPool.syncShutdownGracefully()`, modeled rather closely after `EventLoopGroup.syncShutdownGracefully()`. Shutdown is synchronous from the point of view of calling code. As with any such method, it must not be invoked on any of the `EventLoop`s in the pool's `EventLoopGroup`, otherwise deadlock will result. Any error that occurs is thrown.
- Clean up how `NIO.Lock` is used; now both safer and spends less time with the lock held.
- `EventLoopGroupConnectionPool.requestConnection(logger:on:)` and `EventLoopGroupConnectionPool.withConnection(logger:on:_:)` now check for an "pool was already shut down" condition and fail early.
- Add `EventLoopGroup.future(result:)`, a convenience method for using the corresponding version of `EventLoopPromise.completeWith(_:)`. Useful when working with both futures and `Result`s.
- All AsyncKIt unit tests now bootstrap logging and respect the `LOG_LEVEL` environment variable.
- The `EventLoopFutureQueue` unit tests now run 4 seconds faster.
- A round of CI improvements, including improvements to the code coverage reporting.

Care has been taken not to break any existing API, despite this resulting in the confusing but for-now unavoidable presence of three distinct methods for shutting down pools. Especial care in particular has been taken to ensure that code using the legacy `.shutdown()` method will correctly and safely interoperate with code using the new `.shutdownGracefully(_:)` and `.syncShutdownGracefully()` methods in all cases.