### PR TITLE
Remove unnecessary platforms minimum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,6 @@ import PackageDescription
 
 let package = Package(
     name: "async-kit",
-    platforms: [
-       .macOS(.v10_15)
-    ],
     products: [
         .library(name: "AsyncKit", targets: ["AsyncKit"]),
     ],


### PR DESCRIPTION
This is not necessary and causes error in SQLiteKit:
The package product 'SQLiteNIO' requires minimum platform version 13.0 for the iOS platform, but this target supports 8.0

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
