### PR TITLE
Timeout connection requests when in a deadlock.

### DIFF
--- a/Sources/AsyncKit/ConnectionPool/ConnectionPoolError.swift
+++ b/Sources/AsyncKit/ConnectionPool/ConnectionPoolError.swift
@@ -2,4 +2,6 @@
 public enum ConnectionPoolError: Error {
     /// The connection pool has shutdown.
     case shutdown
+    /// The connection creationg timed out.
+    case connectionCreateTimeout
 }

--- a/Sources/AsyncKit/ConnectionPool/ConnectionPoolError.swift
+++ b/Sources/AsyncKit/ConnectionPool/ConnectionPoolError.swift
@@ -2,6 +2,9 @@
 public enum ConnectionPoolError: Error {
     /// The connection pool has shutdown.
     case shutdown
-    /// The connection creationg timed out.
-    case connectionCreateTimeout
+}
+
+public enum ConnectionPoolTimeoutError: Error {
+    /// The connection request timed out.
+    case connectionRequestTimeout
 }

--- a/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
@@ -216,7 +216,7 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
             }
             
             // return waiter
-            return promise.futureResult.always { _ in task.cancel() }
+            return promise.futureResult
         }
     }
     

--- a/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
@@ -216,7 +216,7 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
             }
             
             // return waiter
-            return promise.futureResult
+            return promise.futureResult.always { _ in task.cancel() }
         }
     }
     

--- a/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
@@ -1,4 +1,5 @@
 import struct Logging.Logger
+import struct NIO.TimeAmount
 import class NIOConcurrencyHelpers.Lock
 import Dispatch
 
@@ -58,6 +59,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
     public init(
         source: Source,
         maxConnectionsPerEventLoop: Int = 1,
+        creationTimeout: TimeAmount = .seconds(10),
         logger: Logger = .init(label: "codes.vapor.pool"),
         on eventLoopGroup: EventLoopGroup
     ) {
@@ -70,6 +72,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
         self.storage = .init(uniqueKeysWithValues: eventLoopGroup.makeIterator().map { ($0.key, .init(
             source: source,
             maxConnections: maxConnectionsPerEventLoop,
+            creationTimeout: creationTimeout,
             logger: logger,
             on: $0
         )) })

--- a/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
@@ -54,12 +54,14 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
     ///     - source: Creates new connections when needed.
     ///     - maxConnectionsPerEventLoop: Limits the number of connections that can be open per event loop.
     ///                                   Defaults to 1.
+    ///     - requestTimeout: Timeout for requesting a new connection.
+    ///                       Defaults to 10 seconds.
     ///     - logger: For lifecycle logs.
     ///     - on: Event loop group.
     public init(
         source: Source,
         maxConnectionsPerEventLoop: Int = 1,
-        creationTimeout: TimeAmount = .seconds(10),
+        requestTimeout: TimeAmount = .seconds(10),
         logger: Logger = .init(label: "codes.vapor.pool"),
         on eventLoopGroup: EventLoopGroup
     ) {
@@ -72,7 +74,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
         self.storage = .init(uniqueKeysWithValues: eventLoopGroup.makeIterator().map { ($0.key, .init(
             source: source,
             maxConnections: maxConnectionsPerEventLoop,
-            creationTimeout: creationTimeout,
+            requestTimeout: requestTimeout,
             logger: logger,
             on: $0
         )) })

--- a/Tests/AsyncKitTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncKitTests/ConnectionPoolTests.swift
@@ -150,6 +150,7 @@ final class ConnectionPoolTests: XCTestCase {
         let a = pool.requestConnection()
         do {
             _ = try a.wait()
+            XCTFail("Connection should have deadlocked and thrown ConnectionPoolError.connectionCreateTimeout")
         } catch {
             let interval = Date().timeIntervalSince(start)
             XCTAssertGreaterThan(interval, 1)

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -225,10 +225,6 @@ fileprivate extension EventLoop {
     }
 }
 
-fileprivate enum Failure: Error, Equatable, CustomStringConvertible {
+fileprivate enum Failure: Error, Equatable {
     case nope
-    
-    var description: String {
-        return "nope"
-    }
 }

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -225,6 +225,10 @@ fileprivate extension EventLoop {
     }
 }
 
-fileprivate enum Failure: Error, Equatable {
+fileprivate enum Failure: Error, Equatable, CustomStringConvertible {
     case nope
+    
+    var description: String {
+        return "nope"
+    }
 }


### PR DESCRIPTION
Fixes a bug when requesting `n+1` connections from a connection pool with limit `n` where each new connection waited on the previous one.

Previously, this would create a deadlock. Now, a timeout can be added to `EventLoopConnectionPool`, that will return a failed future if the timeout is reached. Timeout defaults to 10 seconds but can be configured.
Fixes #63 