### PR TITLE
Fix bug related to swift change in error string conversion

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
+++ b/Sources/AsyncKit/EventLoopFuture/EventLoopFutureQueue.swift
@@ -35,8 +35,6 @@ public final class EventLoopFutureQueue {
             case let .previousError(error):
                 if let sub = error as? ContinueError {
                     return sub.description
-                } else if let convertible = error as? CustomStringConvertible {
-                    return "previousError(\(convertible.description))"
                 } else {
                     return "previousError(\(error))"
                 }


### PR DESCRIPTION
Due to a change in Swift, all Errors became CustomStringConvertible by virtue of implicit bridging with NSError. The check for CustomStringConvertible conformance has been removed. This restores the previous behavior and makes the tests pass again.

Unblocks #67