### PR TITLE
Add "sequenced" variants of flatMapEach() and flatMapEachCompact()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,66 +1,56 @@
-name: Test Matrix
-on:
-  pull_request: 
-  push: { branches: [ master ] }
+name: test
+on: { pull_request: {} }
+
 jobs:
-  tests-linux:
-    strategy:
-      matrix:
-        runner: ['swift:5.2-xenial', 'swift:5.2-bionic',
-                 'swiftlang/swift:nightly-5.2-xenial', 'swiftlang/swift:nightly-5.2-bionic',
-                 'swiftlang/swift:nightly-5.3-xenial', 'swiftlang/swift:nightly-5.3-bionic',
-                 'swiftlang/swift:nightly-master-xenial', 'swiftlang/swift:nightly-master-bionic',
-                 'swiftlang/swift:nightly-master-focal',
-                 'swiftlang/swift:nightly-master-centos8', 'swiftlang/swift:nightly-master-amazonlinux2']
-        include:
-          - installcmd: 'apt-get -q update && apt-get -q install -y curl'
-          - { 'runner': 'swiftlang/swift:nightly-master-centos8', 'installcmd': 'true' }
-          - { 'runner': 'swiftlang/swift:nightly-master-amazonlinux2', 'installcmd': 'true' }
-    container: ${{ matrix.runner }}
-    env:
-      SWIFT_RUNNER: ${{ matrix.runner }}
+  getcidata:
     runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.output.outputs.environments }}
     steps:
-      - name: Install dependencies
-        run: ${{ matrix.installcmd }}
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer and code coverage
-        run: swift test --enable-test-discovery --sanitize=thread --enable-code-coverage
-      - name: Convert data to LCOV format and save location
+      - id: output
         run: |
-          export b=$(swift build --show-bin-path) && llvm-cov export -format lcov \
-          -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
-          $b/async-kitPackageTests.xctest >$(swift test --show-codecov-path).lcov
-          echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
-      - name: Send to codecov.io
-        uses: codecov/codecov-action@v1.0.7
-        with:
-          file: ${{ env.CODECOV_FILE }}
-          flags: unittests
-          env_vars: SWIFT_RUNNER
-          fail_ci_if_error: true
-  tests-macos:
-    runs-on: macos-latest
+          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
+          echo "::set-output name=environments::${envblob}"
+
+  test-asynckit:
+    needs: getcidata
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+    runs-on: ${{ matrix.env.os }}
+    container: ${{ matrix.env.image }}
     env:
-      SWIFT_RUNNER: 'macOS'
-    steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
-        with: { 'xcode-version': 'latest' }
+      SWIFT_RUNNER: ${{ format('{0}-{1}-{2}', matrix.env.os, matrix.env.toolchain, matrix.env.image) }}
+    steps: 
+      - name: Select toolchain
+        uses: maxim-lobanov/setup-xcode@v1.2.1
+        with:
+          xcode-version: ${{ matrix.env.toolchain }}
+        if: ${{ matrix.env.toolchain != '' }}
+      - name: Ensure curl's availability
+        run: apt-get update && apt-get install -y curl
+        if: ${{ matrix.env.image != '' }}
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
+        timeout-minutes: 20
         run: swift test --enable-test-discovery --sanitize=thread --enable-code-coverage
       - name: Convert data to LCOV format and save location
         run: |
-          export b=$(swift build --show-bin-path) && xcrun llvm-cov export -format lcov \
-          -instr-profile=$b/codecov/default.profdata --ignore-filename-regex='\.build/' \
-          $b/async-kitPackageTests.xctest/Contents/MacOS/async-kitPackageTests \
-          >$(swift test --show-codecov-path).lcov
-          echo "::set-env name=CODECOV_FILE::$(swift test --show-codecov-path).lcov"
+          export build=$(swift build --show-bin-path) && \
+          export subpath="$([[ $(uname -s) == "Darwin" ]] && echo "/Contents/MacOS/async-kitPackageTests" || true)" && \
+          export exc_prefix="$([[ $(uname -s) == "Darwin" ]] && echo "xcrun" || true)" && \
+          ${exc_prefix} llvm-cov export \
+              -format lcov \
+              -instr-profile=$build/codecov/default.profdata \
+              --ignore-filename-regex='\.build/' \
+              $build/async-kitPackageTests.xctest$subpath \
+              >$(swift test --show-codecov-path).lcov
+          echo "CODECOV_FILE=$(swift test --show-codecov-path).lcov" >> $GITHUB_ENV
+        shell: bash
       - name: Send to codecov.io
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.14
         with:
           file: ${{ env.CODECOV_FILE }}
           flags: unittests

--- a/Sources/AsyncKit/EventLoopFuture/Future+Collection.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Collection.swift
@@ -42,7 +42,7 @@ extension EventLoopFuture where Value: Sequence {
     /// Calls a closure, which returns an `EventLoopFuture`, on each element
     /// in a sequence that is wrapped by an `EventLoopFuture`.
     ///
-    ///     let users = evetnLoop.future([User(name: "Tanner", ...), ...])
+    ///     let users = eventLoop.future([User(name: "Tanner", ...), ...])
     ///     let saved = users.flatMapEach(on: eventLoop) { $0.save(on: database) }
     ///
     /// - parameters:
@@ -55,9 +55,7 @@ extension EventLoopFuture where Value: Sequence {
         on eventLoop: EventLoop,
         _ transform: @escaping (_ element: Value.Element) -> EventLoopFuture<Result>
     ) -> EventLoopFuture<[Result]> {
-        return self.flatMap { sequence -> EventLoopFuture<[Result]> in
-            return sequence.map(transform).flatten(on: eventLoop)
-        }
+        self.flatMap { .reduce(into: [], $0.map(transform), on: eventLoop) { $0.append($1) } }
     }
     
     /// Calls a closure, which returns an `EventLoopFuture<Optional>`, on each element
@@ -76,14 +74,7 @@ extension EventLoopFuture where Value: Sequence {
         on eventLoop: EventLoop,
         _ transform: @escaping (_ element: Value.Element) -> EventLoopFuture<Result?>
     ) -> EventLoopFuture<[Result]> {
-        return self.flatMap { sequence -> EventLoopFuture<[Result]> in
-            let futures = sequence.map(transform)
-            return EventLoopFuture<[Result]>.reduce(into: [], futures, on: eventLoop) { result, value in
-                if let unwrapped = value {
-                    result.append(unwrapped)
-                }
-            }
-        }
+        self.flatMap { .reduce(into: [], $0.map(transform), on: eventLoop) { res, elem in elem.map { res.append($0) } } }
     }
 
     /// Calls a closure on each element in the sequence that is wrapped by an `EventLoopFuture`.
@@ -128,4 +119,50 @@ extension EventLoopFuture where Value: Sequence {
             return try sequence.compactMap(transform)
         }
     }
+
+    /// A variant form of `flatMapEach(on:_:)` which guarantees:
+    ///
+    /// 1) Explicitly sequential execution of each future returned by the mapping
+    ///    closure; the next future does not being executing until the previous one
+    ///    has yielded a success result.
+    ///
+    /// 2) No further futures will be even paritially executed if any one future
+    ///    returns a failure result.
+    ///
+    /// Neither of these are provided by the original version of the method.
+    public func sequencedFlatMapEach<Result>(_ transform: @escaping (_ element: Value.Element) -> EventLoopFuture<Result>) -> EventLoopFuture<[Result]> {
+        var results: [Result] = []
+        
+        return self.flatMap {
+            $0.reduce(self.eventLoop.future()) { fut, elem in
+                fut.flatMap { transform(elem).map { results.append($0) } }
+            }
+        }.transform(to: results)
+    }
+
+    /// An overload of `sequencedFlatMapEach(_:)` which returns a `Void` future instead
+    /// of `[Void]` when the result type of the transform closure is `Void`.
+    public func sequencedFlatMapEach(_ transform: @escaping (_ element: Value.Element) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+        return self.flatMap {
+            $0.reduce(self.eventLoop.future()) { fut, elem in
+                fut.flatMap { transform(elem) }
+            }
+        }
+    }
+
+    /// Variant of `sequencedFlatMapEach(_:)` which provides `compactMap()` semantics
+    /// by allowing result values to be `nil`. Such results are not included in the
+    /// output array.
+    public func sequencedFlatMapEachCompact<Result>(_ transform: @escaping (_ element: Value.Element) -> EventLoopFuture<Result?>) -> EventLoopFuture<[Result]> {
+        var results: [Result] = []
+        
+        return self.flatMap {
+            $0.reduce(self.eventLoop.future()) { fut, elem in
+                fut.flatMap { transform(elem).map {
+                    $0.map { results.append($0) }
+                } }
+            }
+        }.transform(to: results)
+    }
+    
 }

--- a/Sources/AsyncKit/EventLoopFuture/Future+Collection.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Collection.swift
@@ -126,7 +126,7 @@ extension EventLoopFuture where Value: Sequence {
     ///    closure; the next future does not being executing until the previous one
     ///    has yielded a success result.
     ///
-    /// 2) No further futures will be even paritially executed if any one future
+    /// 2) No further futures will be even partially executed if any one future
     ///    returns a failure result.
     ///
     /// Neither of these are provided by the original version of the method.


### PR DESCRIPTION
These new variants guarantee two specific behaviors:

1. The futures returned for each element of the iterated sequence will be executed singularly and strictly in order. Only one will run at a time, and the order in which they run will match that returned by the transformation callback.

2. If any one of the futures should fail, no other futures will begin execution, even if they were ready to do so.

Additional changes:

- Added new tests for the "sequenced" behaviors,
- Made sure the ELG used for the collections+futures tests has multiple threads, otherwise the tests are meaningless.
- Fixed a couple of typos in comments.
- Simplified the implementations of the original `flatMapEach(on:_:)` and `flatMapEachCompact(on:_:)` (no functional changes).