### PR TITLE
Fix warnings from Swift 5.4 compiler

### DIFF
--- a/Sources/AsyncKit/ConnectionPool/ConnectionPoolItem.swift
+++ b/Sources/AsyncKit/ConnectionPool/ConnectionPoolItem.swift
@@ -1,5 +1,5 @@
 /// Item managed by a connection pool.
-public protocol ConnectionPoolItem: class {
+public protocol ConnectionPoolItem: AnyObject {
     /// EventLoop this connection belongs to.
     var eventLoop: EventLoop { get }
     


### PR DESCRIPTION
Fixes the following warnings now produced by the Swift 5.4 compiler:

```
warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol ConnectionPoolItem: class {
                                    ^~~~~
                                    AnyObject
```
