### PR TITLE
Enable sequencedFlatMapEach() from a plain Collection base

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/Collection+Flatten.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Collection+Flatten.swift
@@ -33,3 +33,35 @@ extension Array where Element == EventLoopFuture<Void> {
         return .andAllSucceed(self, on: eventLoop)
     }
 }
+
+extension Collection {
+    /// Strictly sequentially transforms each element of the collection into an
+    /// `EventLoopFuture`, collects the results of each future, and returns the
+    /// overall result. Identical to `EventLoopFuture.sequencedFlatMapEach(_:)`,
+    /// but does not require the initial collection to be wrapped by a future.
+    public func sequencedFlatMapEach<Result>(
+        on eventLoop: EventLoop,
+        _ transform: @escaping (_ element: Element) -> EventLoopFuture<Result>
+    ) -> EventLoopFuture<[Result]> {
+        return self.reduce(eventLoop.future([])) { fut, elem in fut.flatMap { res in transform(elem).map { res + [$0] } } }
+    }
+
+    /// An overload of `sequencedFlatMapEach(on:_:)` which returns a `Void` future instead
+    /// of `[Void]` when the result type of the transform closure is `Void`.
+    public func sequencedFlatMapEach(
+        on eventLoop: EventLoop,
+        _ transform: @escaping (_ element: Element) -> EventLoopFuture<Void>
+    ) -> EventLoopFuture<Void> {
+        return self.reduce(eventLoop.future()) { fut, elem in fut.flatMap { transform(elem) } }
+    }
+
+    /// Variant of `sequencedFlatMapEach(on:_:)` which provides `compactMap()` semantics
+    /// by allowing result values to be `nil`. Such results are not included in the
+    /// output array.
+    public func sequencedFlatMapEachCompact<Result>(
+        on eventLoop: EventLoop,
+        _ transform: @escaping (_ element: Element) -> EventLoopFuture<Result?>
+    ) -> EventLoopFuture<[Result]> {
+        return self.reduce(eventLoop.future([])) { fut, elem in fut.flatMap { res in transform(elem).map { res + [$0].compactMap { $0 } } } }
+    }
+}

--- a/Tests/AsyncKitTests/Future+CollectionTests.swift
+++ b/Tests/AsyncKitTests/Future+CollectionTests.swift
@@ -115,6 +115,52 @@ final class FutureCollectionTests: XCTestCase {
         XCTAssertEqual(lock.withLock { last }, "3")
     }
 
+    func testELSequencedFlatMapEach() throws {
+        struct SillyRangeError: Error {}
+        var value = 0
+        let lock = Lock()
+        let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let times2 = collection.sequencedFlatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Int> in
+            lock.withLock { value = Swift.max(value, int) }
+            guard int < 5 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            return self.eventLoop.makeSucceededFuture(int * 2)
+        }
+        
+        XCTAssertThrowsError(try times2.wait())
+        XCTAssertLessThan(lock.withLock { value }, 6)
+    }
+
+    func testELSequencedFlatMapVoid() throws {
+        struct SillyRangeError: Error {}
+        var value = 0
+        let lock = Lock()
+        let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let times2 = collection.sequencedFlatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Void> in
+            lock.withLock { value = Swift.max(value, int) }
+            guard int < 5 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            return self.eventLoop.makeSucceededFuture(())
+        }
+        
+        XCTAssertThrowsError(try times2.wait())
+        XCTAssertLessThan(lock.withLock { value }, 6)
+    }
+
+    func testELSequencedFlatMapEachCompact() throws {
+        struct SillyRangeError: Error {}
+        var last = ""
+        let lock = Lock()
+        let collection = ["one", "2", "3", "not", "4", "1", "five", "^", "7"]
+        let times2 = collection.sequencedFlatMapEachCompact(on: self.eventLoop) { val -> EventLoopFuture<Int?> in
+            guard let int = Int(val) else { return self.eventLoop.makeSucceededFuture(nil) }
+            guard int < 4 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            lock.withLock { last = val }
+            return self.eventLoop.makeSucceededFuture(int * 2)
+        }
+        
+        XCTAssertThrowsError(try times2.wait())
+        XCTAssertEqual(lock.withLock { last }, "3")
+    }
+
     /// This test case's EventLoopGroup
     var group: EventLoopGroup!
     


### PR DESCRIPTION
Adds helpers for writing `[1, 2, 3].sequencedFlatMapEach(on: eventLoop) { SomeModel($0).save(on: db) }` instead of `eventLoop.future([1, 2, 3]).sequencedFlatMapEach { }`. More for completeness than anything.