### PR TITLE
Add EventLoopFuture utility methods for handling empty collection values

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/FutureExtensions.swift
+++ b/Sources/AsyncKit/EventLoopFuture/FutureExtensions.swift
@@ -49,7 +49,7 @@ extension EventLoopFuture {
     
     /// Checks that the future's value (if any) returns `false` for `.isEmpty`. If the check fails, the provided error
     /// is thrown.
-    public func nonempty(orError error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> where Value: Collection {
+    public func nonempty<E: Error>(orError error: @escaping @autoclosure () -> E) -> EventLoopFuture<Value> where Value: Collection {
         return self.guard({ !$0.isEmpty }, else: error())
     }
 

--- a/Sources/AsyncKit/EventLoopFuture/FutureExtensions.swift
+++ b/Sources/AsyncKit/EventLoopFuture/FutureExtensions.swift
@@ -1,4 +1,4 @@
-public extension EventLoopFuture {
+extension EventLoopFuture {
     // MARK: - Guard
     
     /// Guards that the future's value satisfies the callback's condition or
@@ -13,7 +13,7 @@ public extension EventLoopFuture {
     ///   - callback: Callback that asynchronously executes a condition.
     ///   - error: The error to fail with if condition isn't met.
     /// - returns: A future containing the original future's result.
-    func `guard`(_ callback: @escaping ((Value) -> Bool), else error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> {
+    public func `guard`(_ callback: @escaping ((Value) -> Bool), else error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> {
         let promise = self.eventLoop.makePromise(of: Value.self)
         self.whenComplete { result in
             switch result {
@@ -36,7 +36,7 @@ public extension EventLoopFuture {
     ///
     /// This is useful when some work must be done for both success and failure states, especially work that requires
     /// temporarily extending the lifetime of one or more objects.
-    func flatMapAlways<NewValue>(
+    public func flatMapAlways<NewValue>(
         file: StaticString = #file, line: UInt = #line,
         _ callback: @escaping (Result<Value, Error>) -> EventLoopFuture<NewValue>
     ) -> EventLoopFuture<NewValue> {
@@ -44,4 +44,50 @@ public extension EventLoopFuture {
         self.whenComplete { result in callback(result).cascade(to: promise) }
         return promise.futureResult
     }
+    
+    // MARK: - nonempty
+    
+    /// Checks that the future's value (if any) returns `false` for `.isEmpty`. If the check fails, the provided error
+    /// is thrown.
+    public func nonempty(orError error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> where Value: Collection {
+        return self.guard({ !$0.isEmpty }, else: error())
+    }
+
+    /// Checks that the future's value (if any) returns `false` for `.isEmpty`. If the check fails, a new future with
+    /// the provided alternate value is returned. Otherwise, the provided normal `map()` callback is invoked.
+    public func nonemptyMap<NewValue>(
+        or alternate: @escaping @autoclosure () -> NewValue,
+        _ transform: @escaping (Value) -> NewValue
+    ) -> EventLoopFuture<NewValue> where Value: Collection {
+        return self.map { !$0.isEmpty ? transform($0) : alternate() }
+    }
+
+    /// Checks that the future's value (if any) returns `false` for `.isEmpty`. If the check fails, a new future with
+    /// an empty array as its value is returned. Otherwise, the provided normal `map()` callback is invoked. The
+    /// callback's return type must be an `Array` or a `RangeReplaceableCollection`.
+    public func nonemptyMap<NewValue>(
+        _ transform: @escaping (Value) -> NewValue
+    ) -> EventLoopFuture<NewValue> where Value: Collection, NewValue: RangeReplaceableCollection {
+        return self.nonemptyMap(or: .init(), transform)
+    }
+
+    /// Checks that the future's value (if any) returns `false` for `.isEmpty`. If the check fails, a new future with
+    /// the provided alternate value is returned. Otherwise, the provided normal `flatMapThrowing()` callback is
+    /// invoked.
+    public func nonemptyFlatMapThrowing<NewValue>(
+        or alternate: @escaping @autoclosure () -> NewValue,
+        _ transform: @escaping (Value) throws -> NewValue
+    ) -> EventLoopFuture<NewValue> where Value: Collection {
+        return self.flatMapThrowing { !$0.isEmpty ? try transform($0) : alternate() }
+    }
+
+    /// Checks that the future's value (if any) returns `false` for `.isEmpty`. If the check fails, a new future with
+    /// an empty array as its value is returned. Otherwise, the provided normal `flatMapThrowing()` callback is
+    /// invoked. The callback's return type must be an `Array` or a `RangeReplaceableCollection`.
+    public func nonemptyFlatMapThrowing<NewValue>(
+        _ transform: @escaping (Value) throws -> NewValue
+    ) -> EventLoopFuture<NewValue> where Value: Collection, NewValue: RangeReplaceableCollection {
+        return self.nonemptyFlatMapThrowing(or: .init(), transform)
+    }
+
 }

--- a/Tests/AsyncKitTests/FutureExtensionsTests.swift
+++ b/Tests/AsyncKitTests/FutureExtensionsTests.swift
@@ -22,6 +22,23 @@ final class FutureExtensionsTests: XCTestCase {
         try XCTAssertThrowsError(future2.wait())
     }
     
+    func testNonempty() {
+        try XCTAssertNoThrow(self.eventLoop.future([0]).nonempty(orError: TestError.notEqualTo1).wait())
+        try XCTAssertThrowsError(self.eventLoop.future([]).nonempty(orError: TestError.notEqualTo1).wait())
+        
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyMap(or: 1, { $0[0] }).wait(), 0)
+        XCTAssertEqual(try self.eventLoop.future([]).nonemptyMap(or: 1, { $0[0] }).wait(), 1)
+
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyMap({ [$0[0]] }).wait(), [0])
+        XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyMap({ [$0[0]] }).wait(), [])
+
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMapThrowing(or: 1, { (a) throws -> Int in a[0] }).wait(), 0)
+        XCTAssertEqual(try self.eventLoop.future([]).nonemptyFlatMapThrowing(or: 1, { (a) throws -> Int in a[0] }).wait(), 1)
+
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).wait(), [0])
+        XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).wait(), [])
+    }
+    
     /// This TestCases EventLoopGroup
     var group: EventLoopGroup!
     

--- a/Tests/AsyncKitTests/FutureExtensionsTests.swift
+++ b/Tests/AsyncKitTests/FutureExtensionsTests.swift
@@ -37,6 +37,16 @@ final class FutureExtensionsTests: XCTestCase {
 
         XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).wait(), [0])
         XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).wait(), [])
+
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMap(or: 1, { self.eventLoop.future($0[0]) }).wait(), 0)
+        XCTAssertEqual(try self.eventLoop.future([]).nonemptyFlatMap(or: 1, { self.eventLoop.future($0[0]) }).wait(), 1)
+
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMap(orFlat: self.eventLoop.future(1), { self.eventLoop.future($0[0]) }).wait(), 0)
+        XCTAssertEqual(try self.eventLoop.future([]).nonemptyFlatMap(orFlat: self.eventLoop.future(1), { self.eventLoop.future($0[0]) }).wait(), 1)
+
+        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMap({ self.eventLoop.future([$0[0]]) }).wait(), [0])
+        XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyFlatMap({ self.eventLoop.future([$0[0]]) }).wait(), [])
+
     }
     
     /// This TestCases EventLoopGroup


### PR DESCRIPTION
Provides:
- `EventLoopFuture.nonempty(orError:)`: If the future's `Collection`-conforming value is empty, fails the future with the provided error.
- `EventLoopFuture.nonemptyMap(or:_:)`: If the future's `Collection`-conforming value is empty, returns the provided alternate value, otherwise acts like `.map(_:)`.
- `EventLoopFuture.nonemptyMap(_:)`: If the future's `Collection`-conforming value is empty, returns an empty instance of the `RangeReplaceableCollection`-conforming result value, otherwise acts like `.map(_:)`.
- `EventLoopFuture.nonemptyFlatMapThrowing(or:_:)`: If the future's `Collection`-conforming value is empty, returns the provided alternate value, otherwise acts like `.flatMapThrowing(_:)`.
- `EventLoopFuture.nonemptyFlatMapThrowing(_:)`: If the future's `Collection`-conforming value is empty, returns an empty instance of the `RangeReplaceableCollection`-conforming result value, otherwise acts like `.flatMapThrowing(_:)`.
- `EventLoopFuture.nonemptyFlatMap(or:_:)`: If the future's `Collection`-conforming value is empty, returns a future with the provided alternate value, otherwise acts like `.flatMap(_:)`.
- `EventLoopFuture.nonemptyFlatMap(orFlat:_:)`: If the future's `Collection`-conforming value is empty, returns the provided alternate future, otherwise acts like `.flatMap(_:)`.
- `EventLoopFuture.nonemptyFlatMap(_:)`: If the future's `Collection`-conforming value is empty, returns a future with an empty instance of the `RangeReplaceableCollection`-conforming result value, otherwise acts like `.flatMap(_:)`.

Example usage:

```swift
return MyModel.query(on: request.db)
    .filter(\.foo == bar)
    .all()
    .nonempty(orError: Abort(.notFound))
    .map { ...
```

```swift
return MyModel.query(on: request.db)
    .filter(\.foo == bar)
    .all()
    .nonemptyMap { models -> [Something] in
        ...
```