### PR TITLE
Add `EventLoopFuture.tryFlatMap()` by popular demand

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/Future+Try.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Try.swift
@@ -1,0 +1,24 @@
+import NIO
+
+extension EventLoopFuture {
+    public func tryFlatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Value) throws -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
+        /// When the current `EventLoopFuture<Value>` is fulfilled, run the provided callback,
+        /// which will provide a new `EventLoopFuture`.
+        ///
+        /// This allows you to dynamically dispatch new asynchronous tasks as phases in a
+        /// longer series of processing steps. Note that you can use the results of the
+        /// current `EventLoopFuture<Value>` when determining how to dispatch the next operation.
+        ///
+        /// The key difference between this method and the regular `flatMap` is  error handling.
+        ///
+        /// With `tryFlatMap`, the provided callback _may_ throw Errors, causing the returned `EventLoopFuture<Value>`
+        /// to report failure immediately after the completion of the original `EventLoopFuture`.
+        flatMap(file: file, line: line) { [eventLoop] value in
+            do {
+                return try callback(value)
+            } catch {
+                return eventLoop.makeFailedFuture(error, file: file, line: line)
+            }
+        }
+    }
+}

--- a/Tests/AsyncKitTests/Future+TryTests.swift
+++ b/Tests/AsyncKitTests/Future+TryTests.swift
@@ -1,0 +1,48 @@
+import NIO
+import AsyncKit
+import XCTest
+
+final class FutureTryTests: XCTestCase {
+    private let eventLoop = EmbeddedEventLoop()
+
+    private enum NIOError: Error {
+        case testError
+    }
+
+    func testTryFlatMapPropagatesCallbackError() {
+        let future = eventLoop.future(0)
+            .tryFlatMap { _ -> EventLoopFuture<String> in
+                throw NIOError.testError
+            }
+
+        XCTAssertThrowsError(try future.wait()) { error in
+            guard case NIOError.testError = error else {
+                XCTFail("Received an unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testTryFlatMapPropagatesInnerError() {
+        let future = eventLoop.future(0)
+            .tryFlatMap { _ -> EventLoopFuture<String> in
+                self.eventLoop.makeFailedFuture(NIOError.testError)
+            }
+
+        XCTAssertThrowsError(try future.wait()) { error in
+            guard case NIOError.testError = error else {
+                XCTFail("Received an unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testTryFlatMapPropagatesResult() throws {
+        let future = eventLoop.future(0)
+            .tryFlatMap { value -> EventLoopFuture<String> in
+                self.eventLoop.makeSucceededFuture(String(describing: value))
+            }
+
+        try XCTAssertEqual("0", future.wait())
+    }
+}


### PR DESCRIPTION
One of the most common hurdles of working with EventLoopFutures, and a very oft-repeated question on the Discord server is interacting with error-throwing code. The `tryFlatMap` extension alleviates that by handling any errors thrown by the closure, causing the ELF to fail.

This is the most common error handling pattern anyway.