### PR TITLE
adding `performWithTask` convenience func to convert async works to futures

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/Future+Throwing.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Throwing.swift
@@ -26,5 +26,20 @@ extension EventLoopGroup {
     public func tryFuture<T>(_ work: @escaping () throws -> T) -> EventLoopFuture<T> {
         return self.next().submit(work)
     }
+    
+#if compiler(>=5.5) && canImport(_Concurrency)
+    /// Performs an async work and returns the result in form of an `EventLoopFuture`.
+    ///
+    /// - Parameter work: The async, potentially throwing closure to execute as a
+    ///   future. If the closure throws, a failed future is returned.
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    public func performWithTask<T>(
+        _ work: @escaping @Sendable () async throws -> T
+    ) -> EventLoopFuture<T> {
+        let promise = self.next().makePromise(of: T.self)
+        promise.completeWithTask(work)
+        return promise.futureResult
+    }
+#endif
 }
 

--- a/Tests/AsyncKitTests/FutureExtensionsTests.swift
+++ b/Tests/AsyncKitTests/FutureExtensionsTests.swift
@@ -63,6 +63,21 @@ final class FutureExtensionsTests: XCTestCase {
 
     }
     
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    func testPerformWithTask() throws {
+        @Sendable
+        func getOne() async throws -> Int {
+            return 1
+        }
+        let expectedOne = self.eventLoop.performWithTask {
+            try await getOne()
+        }
+        
+        XCTAssertEqual(try expectedOne.wait(), 1)
+    }
+#endif
+    
     /// This TestCases EventLoopGroup
     var group: EventLoopGroup!
     


### PR DESCRIPTION
This PR adds a convenience function to convert async works to futures, and reduces the need to directly use promises.

As an example, if you have the code below:
```swift
let promise = eventLoop.makePromise(of: SomeType.self)
promise.completeWithTask {
    try await myAsyncFunc()
}
return promise.futureResult
```
It can be reduced to:
```swift
return eventLoop.performWithTask {
    try await myAsyncFunc()
}
```