### PR TITLE
Removed file:line: from signature and code in Future+Try.swift

### DIFF
--- a/Sources/AsyncKit/EventLoopFuture/Future+Try.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Try.swift
@@ -13,11 +13,11 @@ extension EventLoopFuture {
         ///
         /// With `tryFlatMap`, the provided callback _may_ throw Errors, causing the returned `EventLoopFuture<Value>`
         /// to report failure immediately after the completion of the original `EventLoopFuture`.
-        return self.flatMap(file: file, line: line) { [eventLoop] value in
+        return self.flatMap() { [eventLoop] value in
             do {
                 return try callback(value)
             } catch {
-                return eventLoop.makeFailedFuture(error, file: file, line: line)
+                return eventLoop.makeFailedFuture(error)
             }
         }
     }

--- a/Sources/AsyncKit/EventLoopFuture/Future+Try.swift
+++ b/Sources/AsyncKit/EventLoopFuture/Future+Try.swift
@@ -1,7 +1,10 @@
 import NIO
 
 extension EventLoopFuture {
-    public func tryFlatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Value) throws -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
+    public func tryFlatMap<NewValue>(
+        file _: StaticString = #file, line _: UInt = #line,
+        _ callback: @escaping (Value) throws -> EventLoopFuture<NewValue>
+    ) -> EventLoopFuture<NewValue> {
         /// When the current `EventLoopFuture<Value>` is fulfilled, run the provided callback,
         /// which will provide a new `EventLoopFuture`.
         ///


### PR DESCRIPTION
removed due to depreciation warnings issued with latest Vapor.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Removes depreciated parameters `file:line:` from method signature and calling method.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
