### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/main-codecov.yml
+++ b/.github/workflows/main-codecov.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-main-codecov:
     runs-on: ubuntu-latest
-    container: swift:5.5-focal
+    container: swift:5.6-focal
     steps:
       - name: Check out main
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,64 +2,8 @@ name: test
 on: { pull_request: {} }
 
 jobs:
-  linux-all:
-    strategy:
-      fail-fast: false
-      matrix:
-        swiftver:
-          - swift:5.2
-          - swift:5.3
-          - swift:5.4
-          - swift:5.5
-          - swiftlang/swift:nightly-main
-        swiftos:
-          - focal
-    container: ${{ format('{0}-{1}', matrix.swiftver, matrix.swiftos) }}
-    runs-on: ubuntu-latest
-    env:
-      LOG_LEVEL: debug
-    steps:
-      - name: Check out package
-        uses: actions/checkout@v2
-      - name: Run tests with code coverage and Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread --enable-code-coverage
-      - name: Submit coverage report to Codecov.io
-        uses: vapor/swift-codecov-action@v0.1.1
-        with:
-          cc_flags: 'unittests'
-          cc_env_vars: 'SWIFT_VERSION,SWIFT_PLATFORM,RUNNER_OS,RUNNER_ARCH'
-          cc_fail_ci_if_error: true
-          cc_verbose: true
-
-  macos-all:
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode:
-          - latest-stable
-          - latest
-        include:
-          - xcode: latest-stable
-            filter: '--skip=^AsyncKitTests.EventLoopConcurrencyTests'
-    runs-on: macos-11
-    env:
-      LOG_LEVEL: debug
-    steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.xcode }}
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Run tests with code coverage and Thread Sanitizer
-        run: |
-          swift test --enable-test-discovery ${{ matrix.filter }} --sanitize=thread --enable-code-coverage \
-            -Xlinker -rpath \
-            -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
-      - name: Submit coverage report to Codecov.io
-        uses: vapor/swift-codecov-action@v0.1.1
-        with:
-          cc_flags: 'unittests'
-          cc_env_vars: 'MD_APPLE_SDK_ROOT,RUNNER_OS,RUNNER_ARCH'
-          cc_fail_ci_if_error: true
-          cc_verbose: true
+  unit-tests:
+     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+     with:
+       with_coverage: true
+       with_tsan: true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)