### PR TITLE
Migrate to `NIOLock`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,13 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.10.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [
         .target(name: "AsyncKit", dependencies: [
             .product(name: "Logging", package: "swift-log"),
             .product(name: "NIO", package: "swift-nio"),
+            .product(name: "Atomics", package: "swift-atomics"),
         ]),
         .testTarget(name: "AsyncKitTests", dependencies: [
             .target(name: "AsyncKit")

--- a/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopGroupConnectionPool.swift
@@ -1,4 +1,5 @@
 import struct Logging.Logger
+import NIOConcurrencyHelpers
 import struct NIO.TimeAmount
 import class NIOConcurrencyHelpers.Lock
 import Dispatch
@@ -35,7 +36,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
     private let logger: Logger
     
     /// Synchronize access.
-    private let lock: Lock
+    private let lock: NIOLock
 
     /// If `true`, this connection pool has been closed.
     private var didShutdown: Bool
@@ -207,7 +208,7 @@ public final class EventLoopGroupConnectionPool<Source> where Source: Connection
         // - TODO: Does this need to assert "not on any EventLoop", as `EventLoopGroup.syncShutdownGracefully()` does?
         var possibleError: Error? = nil
         let waiter = DispatchWorkItem {}
-        let errorLock = Lock()
+        let errorLock = NIOLock()
         
         self.shutdownGracefully {
             if let error = $0 {

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -6,7 +6,7 @@ final class EventLoopFutureQueueTests: XCTestCase {
     func testQueue() throws {
         let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
         var numbers: [Int] = []
-        let lock = Lock()
+        let lock = NIOLock()
 
         let one = queue.append(generator: {
             self.eventLoop.slowFuture(1).map { number -> Int in
@@ -51,7 +51,7 @@ final class EventLoopFutureQueueTests: XCTestCase {
     func testAutoclosure() throws {
         let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
         var numbers: [Int] = []
-        let lock = Lock()
+        let lock = NIOLock()
 
         let one = queue.append(self.eventLoop.slowFuture(1, sleeping: 1).map { num in lock.withLockVoid { numbers.append(num) } })
         let two = queue.append(self.eventLoop.slowFuture(2, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })

--- a/Tests/AsyncKitTests/Future+CollectionTests.swift
+++ b/Tests/AsyncKitTests/Future+CollectionTests.swift
@@ -111,7 +111,7 @@ final class FutureCollectionTests: XCTestCase {
     func testSequencedFlatMapEach() throws {
         struct SillyRangeError: Error {}
         var value = 0
-        let lock = Lock()
+        let lock = NIOLock()
         let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
         let times2 = collection.sequencedFlatMapEach { int -> EventLoopFuture<Int> in
             lock.withLock { value = Swift.max(value, int) }
@@ -126,7 +126,7 @@ final class FutureCollectionTests: XCTestCase {
     func testSequencedFlatMapVoid() throws {
         struct SillyRangeError: Error {}
         var value = 0
-        let lock = Lock()
+        let lock = NIOLock()
         let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
         let times2 = collection.sequencedFlatMapEach { int -> EventLoopFuture<Void> in
             lock.withLock { value = Swift.max(value, int) }
@@ -141,7 +141,7 @@ final class FutureCollectionTests: XCTestCase {
     func testSequencedFlatMapEachCompact() throws {
         struct SillyRangeError: Error {}
         var last = ""
-        let lock = Lock()
+        let lock = NIOLock()
         let collection = self.eventLoop.makeSucceededFuture(["one", "2", "3", "not", "4", "1", "five", "^", "7"])
         let times2 = collection.sequencedFlatMapEachCompact { val -> EventLoopFuture<Int?> in
             guard let int = Int(val) else { return self.eventLoop.makeSucceededFuture(nil) }
@@ -157,7 +157,7 @@ final class FutureCollectionTests: XCTestCase {
     func testELSequencedFlatMapEach() throws {
         struct SillyRangeError: Error {}
         var value = 0
-        let lock = Lock()
+        let lock = NIOLock()
         let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         let times2 = collection.sequencedFlatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Int> in
             lock.withLock { value = Swift.max(value, int) }
@@ -172,7 +172,7 @@ final class FutureCollectionTests: XCTestCase {
     func testELSequencedFlatMapVoid() throws {
         struct SillyRangeError: Error {}
         var value = 0
-        let lock = Lock()
+        let lock = NIOLock()
         let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         let times2 = collection.sequencedFlatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Void> in
             lock.withLock { value = Swift.max(value, int) }
@@ -187,7 +187,7 @@ final class FutureCollectionTests: XCTestCase {
     func testELSequencedFlatMapEachCompact() throws {
         struct SillyRangeError: Error {}
         var last = ""
-        let lock = Lock()
+        let lock = NIOLock()
         let collection = ["one", "2", "3", "not", "4", "1", "five", "^", "7"]
         let times2 = collection.sequencedFlatMapEachCompact(on: self.eventLoop) { val -> EventLoopFuture<Int?> in
             guard let int = Int(val) else { return self.eventLoop.makeSucceededFuture(nil) }


### PR DESCRIPTION
Migrates usages of `Lock` to `NIOLock` to fix deprecation warnings