### PR TITLE
Back deploy concurrency to older Apple Platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.5.2
 import PackageDescription
 
 let package = Package(
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "AsyncKit", targets: ["AsyncKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.44.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
     ],

--- a/Sources/AsyncKit/EventLoop/EventLoop+Concurrency.swift
+++ b/Sources/AsyncKit/EventLoop/EventLoop+Concurrency.swift
@@ -14,7 +14,7 @@ extension EventLoop {
     /// - returns: An `EventLoopFuture` which is completed when `body` finishes. On
     ///   success the future has the result returned by `body`; if `body` throws an
     ///   error, the future is failed with that error.
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @inlinable
     public func performWithTask<Value>(
         _ body: @escaping @Sendable () async throws -> Value

--- a/Sources/AsyncKit/EventLoop/EventLoop+Concurrency.swift
+++ b/Sources/AsyncKit/EventLoop/EventLoop+Concurrency.swift
@@ -14,7 +14,7 @@ extension EventLoop {
     /// - returns: An `EventLoopFuture` which is completed when `body` finishes. On
     ///   success the future has the result returned by `body`; if `body` throws an
     ///   error, the future is failed with that error.
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
     @inlinable
     public func performWithTask<Value>(
         _ body: @escaping @Sendable () async throws -> Value

--- a/Sources/AsyncKit/EventLoop/EventLoopGroup+Concurrency.swift
+++ b/Sources/AsyncKit/EventLoop/EventLoopGroup+Concurrency.swift
@@ -14,7 +14,7 @@ extension EventLoopGroup {
     /// - returns: An `EventLoopFuture` which is completed when `body` finishes. On
     ///   success the future has the result returned by `body`; if `body` throws an
     ///   error, the future is failed with that error.
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @inlinable
     public func performWithTask<Value>(
         _ body: @escaping @Sendable () async throws -> Value

--- a/Sources/AsyncKit/EventLoop/EventLoopGroup+Concurrency.swift
+++ b/Sources/AsyncKit/EventLoop/EventLoopGroup+Concurrency.swift
@@ -14,7 +14,7 @@ extension EventLoopGroup {
     /// - returns: An `EventLoopFuture` which is completed when `body` finishes. On
     ///   success the future has the result returned by `body`; if `body` throws an
     ///   error, the future is failed with that error.
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
     @inlinable
     public func performWithTask<Value>(
         _ body: @escaping @Sendable () async throws -> Value

--- a/Tests/AsyncKitTests/EventLoop+ConcurrencyTests.swift
+++ b/Tests/AsyncKitTests/EventLoop+ConcurrencyTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 import AsyncKit
 
-@available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class EventLoopConcurrencyTests: XCTestCase {
     func testGroupPerformWithTask() throws {
         @Sendable

--- a/Tests/AsyncKitTests/EventLoop+ConcurrencyTests.swift
+++ b/Tests/AsyncKitTests/EventLoop+ConcurrencyTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 import AsyncKit
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
 final class EventLoopConcurrencyTests: XCTestCase {
     func testGroupPerformWithTask() throws {
         @Sendable


### PR DESCRIPTION
Enables concurrency features on macOS 10.15 et al. Drops support for Swift 5.5.0 and 5.5.1 to match SwiftNIO