### PR TITLE
Heavily revise the implementation of EventLoopConnectionPool

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,15 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.46.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "AsyncKit", dependencies: [
             .product(name: "Logging", package: "swift-log"),
             .product(name: "NIO", package: "swift-nio"),
+            .product(name: "Collections", package: "swift-collections"),
+            .product(name: "Algorithms", package: "swift-algorithms"),
         ]),
         .testTarget(name: "AsyncKitTests", dependencies: [
             .target(name: "AsyncKit"),

--- a/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
@@ -1,6 +1,8 @@
+import Atomics
 import struct Logging.Logger
 import struct Foundation.UUID
 import NIOCore
+import Collections
 
 /// Holds a collection of active connections that can be requested and later released
 /// back into the pool.
@@ -17,12 +19,13 @@ import NIOCore
 ///     pool.withConnection(...) { conn in
 ///         // use conn
 ///     }
-///
 public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolSource {
+    private typealias WaitlistItem = (logger: Logger, promise: EventLoopPromise<Source.Connection>, timeoutTask: Scheduled<Void>)
+    
     /// Connection source.
     public let source: Source
     
-    /// Max connections for this storage.
+    /// Max connections for this pool.
     private let maxConnections: Int
     
     /// Timeout for requesting a new connection.
@@ -31,16 +34,19 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     /// This pool's event loop.
     public let eventLoop: EventLoop
     
+    /// ID generator
+    private var idGenerator = ManagedAtomic(0)
+    
     /// All currently available connections.
-    /// - note: These connections may have closed since last use.
-    private var available: CircularBuffer<Source.Connection>
+    ///
+    /// > Note: Any connection in this list may have become invalid since its last use.
+    private var available: Deque<Source.Connection>
     
     /// Current active connection count.
     private var activeConnections: Int
     
-    /// All requests for a connection that were unable to be fulfilled
-    /// due to max connection limit having been reached.
-    private var waiters: CircularBuffer<(Logger, EventLoopPromise<Source.Connection>)>
+    /// Connection requests waiting to be fulfilled due to pool exhaustion.
+    private var waiters: OrderedDictionary<Int, WaitlistItem>
     
     /// If `true`, this storage has been shutdown.
     private var didShutdown: Bool
@@ -48,21 +54,19 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     /// For lifecycle logs.
     public let logger: Logger
 
-    /// Creates a new `EventLoopConnectionPool`.
+    /// Creates a new ``EventLoopConnectionPool``.
     ///
     ///     let pool = EventLoopConnectionPool(...)
     ///     pool.withConnection(...) { conn in
     ///         // use conn
     ///     }
     ///
-    /// - parameters:
-    ///     - source: Creates new connections when needed.
-    ///     - maxConnections: Limits the number of connections that can be open.
-    ///                       Defaults to 1.
-    ///     - requestTimeout: Timeout for requesting a new connection.
-    ///                       Defaults to 10 seconds.
-    ///     - logger: For lifecycle logs.
-    ///     - on: Event loop.
+    /// - Parameters:
+    ///   - source: Creates new connections when needed.
+    ///   - maxConnections: Limits the number of connections that can be open. Defaults to 1.
+    ///   - requestTimeout: Timeout for requesting a new connection. Defaults to 10 seconds.
+    ///   - logger: For lifecycle logs.
+    ///   - on: Event loop.
     public init(
         source: Source,
         maxConnections: Int,
@@ -75,9 +79,9 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
         self.requestTimeout = requestTimeout
         self.logger = logger
         self.eventLoop = eventLoop
-        self.available = .init(initialCapacity: maxConnections)
+        self.available = .init(minimumCapacity: maxConnections)
         self.activeConnections = 0
-        self.waiters = .init()
+        self.waiters = .init(minimumCapacity: maxConnections << 2)
         self.didShutdown = false
     }
     
@@ -90,11 +94,11 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     ///         // use the connection
     ///     }
     ///
-    /// See `requestConnection(on:)` to request a pooled connection without using a callback.
+    /// See ``requestConnection()`` to request a pooled connection without using a callback.
     ///
-    /// - parameters:
-    ///     - closure: Callback that accepts the pooled connection.
-    /// - returns: A future containing the result of the closure.
+    /// - Parameters:
+    ///   - closure: Callback that accepts the pooled connection.
+    /// - Returns: A future containing the result of the closure.
     public func withConnection<Result>(
         _ closure: @escaping (Source.Connection) -> EventLoopFuture<Result>
     ) -> EventLoopFuture<Result> {
@@ -110,114 +114,123 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     ///         // use the connection
     ///     }
     ///
-    /// See `requestConnection(on:)` to request a pooled connection without using a callback.
+    /// See ``requestConnection(logger:)`` to request a pooled connection without using a callback.
     ///
-    /// - parameters:
-    ///     - logger: For trace and debug logs.
-    ///     - closure: Callback that accepts the pooled connection.
-    /// - returns: A future containing the result of the closure.
+    /// - Parameters:
+    ///   - logger: For trace and debug logs.
+    ///   - closure: Callback that accepts the pooled connection.
+    /// - Returns: A future containing the result of the closure.
     public func withConnection<Result>(
         logger: Logger,
         _ closure: @escaping (Source.Connection) -> EventLoopFuture<Result>
     ) -> EventLoopFuture<Result> {
-        return self.requestConnection(logger: logger).flatMap { conn in
-            return closure(conn).map { res in
+        self.requestConnection(logger: logger).flatMap { conn in
+            closure(conn).always { _ in
                 self.releaseConnection(conn, logger: logger)
-                return res
-            }.flatMapErrorThrowing { error in
-                self.releaseConnection(conn, logger: logger)
-                throw error
             }
         }
     }
     
     /// Requests a pooled connection.
     ///
-    /// The connection returned by this method should be released when you are finished using it.
+    /// The connection returned by this method MUST be released when you are finished using it.
     ///
     ///     let conn = try pool.requestConnection(...).wait()
     ///     defer { pool.releaseConnection(conn) }
     ///     // use the connection
     ///
-    /// See `withConnection(_:)` for a callback-based method that automatically releases the connection.
+    /// See ``withConnection(_:)`` for a callback-based method that automatically releases the connection.
     ///
-    /// - returns: A future containing the requested connection.
+    /// - Returns: A future containing the requested connection.
     public func requestConnection() -> EventLoopFuture<Source.Connection> {
         self.requestConnection(logger: self.logger)
     }
     
     /// Requests a pooled connection.
     ///
-    /// The connection returned by this method should be released when you are finished using it.
+    /// The connection returned by this method MUST be released when you are finished using it.
     ///
     ///     let conn = try pool.requestConnection(...).wait()
     ///     defer { pool.releaseConnection(conn) }
     ///     // use the connection
     ///
-    /// See `withConnection(_:)` for a callback-based method that automatically releases the connection.
+    /// See ``withConnection(logger:_:)`` for a callback-based method that automatically releases the connection.
     ///
     /// - parameters:
     ///     - logger: For trace and debug logs.
     ///     - eventLoop: Preferred event loop for the new connection.
     /// - returns: A future containing the requested connection.
     public func requestConnection(logger: Logger) -> EventLoopFuture<Source.Connection> {
-        // dispatch to event loop thread if necessary
-        guard self.eventLoop.inEventLoop else {
-            return self.eventLoop.flatSubmit {
-                self.requestConnection(logger: logger)
-            }
+        /// N.B.: This particular pattern (the use of a promise to forward the result when off the event loop)
+        /// is straight out of NIO's `EventLoopFuture.fold()` implementation.
+        if self.eventLoop.inEventLoop {
+            return self._requestConnection0(logger: logger)
+        } else {
+            let promise = self.eventLoop.makePromise(of: Source.Connection.self)
+            self.eventLoop.execute { self._requestConnection0(logger: logger).cascade(to: promise) }
+            return promise.futureResult
         }
+    }
+    
+    /// Actual implementation of ``requestConnection(logger:)``.
+    private func _requestConnection0(logger: Logger) -> EventLoopFuture<Source.Connection> {
+        self.eventLoop.assertInEventLoop()
         
-        // synchronize access to available / active connection checks
         guard !self.didShutdown else {
             return self.eventLoop.makeFailedFuture(ConnectionPoolError.shutdown)
         }
         
-        // creates a new connection assuming `activeConnections`
-        // has already been incremented
-        func makeActiveConnection() -> EventLoopFuture<Source.Connection> {
-            return self.source.makeConnection(logger: logger, on: eventLoop).flatMapErrorThrowing { error in
-                self.activeConnections -= 1
-                throw error
-            }
-        }
-
-        // iterate over available connections
-        while let conn = self.available.popFirst() {
-            // check if it is still open
+        // Find an available connection that isn't closed
+        while let conn = self.available.popLast() {
             if !conn.isClosed {
-                // connection is still open, we can return it directly
-                logger.trace("Re-using available connection")
-                return eventLoop.makeSucceededFuture(conn)
+                logger.trace("Using available connection")
+                return self.eventLoop.makeSucceededFuture(conn)
             } else {
-                // connection is closed
-                logger.debug("Pruning available connection that has closed")
+                logger.debug("Pruning defunct connection")
                 self.activeConnections -= 1
             }
         }
         
-        // all connections are busy, check if we have room for more
-        if self.activeConnections < self.maxConnections {
-            logger.debug("No available connections on this event loop, creating a new one")
-            self.activeConnections += 1
-            return makeActiveConnection()
-        } else {
-            // connections are exhausted, we must wait for one to be returned
-            logger.debug("Connection pool exhausted on this event loop, adding request to waitlist")
-            let promise = eventLoop.makePromise(of: Source.Connection.self)
-            self.waiters.append((logger, promise))
-            
-            let task = eventLoop.scheduleTask(in: self.requestTimeout) { [weak self] in
-                guard let self = self else { return }
-                logger.error("Connection request timed out. This might indicate a connection deadlock in your application. If you're running long running requests, consider increasing your connection timeout.")
-                if let idx = self.waiters.firstIndex(where: { _, p in return p.futureResult === promise.futureResult }) {
-                    self.waiters.remove(at: idx)
-                }
-                promise.fail(ConnectionPoolTimeoutError.connectionRequestTimeout)
+        // Put the current request on the waiter list in case opening a new connection is slow
+        let waiterId = self.idGenerator.wrappingIncrementThenLoad(ordering: .relaxed)
+        let promise = self.eventLoop.makePromise(of: Source.Connection.self)
+        let timeoutTask = self.eventLoop.scheduleTask(in: self.requestTimeout) { [weak self] in
+            // Try to avoid a spurious log message and failure if the waiter has already been removed from the list.
+            guard self?.waiters.removeValue(forKey: waiterId) != nil else {
+                logger.trace("Waiter \(waiterId) already removed when timeout task fired")
+                return
             }
-            
-            return promise.futureResult.always { _ in task.cancel() }
+            logger.error("""
+                Connection request (ID \(waiterId) timed out. This might indicate a connection deadlock in \
+                your application. If you have long-running requests, consider increasing your connection timeout.
+                """)
+            promise.fail(ConnectionPoolTimeoutError.connectionRequestTimeout)
         }
+        logger.trace("Adding connection request to waitlist with ID \(waiterId)")
+        self.waiters[waiterId] = (logger: logger, promise: promise, timeoutTask: timeoutTask)
+        
+        promise.futureResult.whenComplete { [weak self] _ in
+            logger.trace("Connection request with ID \(waiterId) completed")
+            timeoutTask.cancel()
+            self?.waiters.removeValue(forKey: waiterId)
+        }
+
+        // If the pool isn't full, attempt to open a new connection
+        if self.activeConnections < self.maxConnections {
+            logger.trace("Attemping new connection for pool")
+            self.activeConnections += 1
+            self.source.makeConnection(logger: logger, on: self.eventLoop).map {
+                // On success, "release" the new connection to the pool and let the waitlist logic take over
+                logger.trace("New connection successful, servicing waitlist")
+                self._releaseConnection0($0, logger: logger)
+            }.flatMapErrorWithEventLoop { [weak self] error, eventLoop in
+                self?.activeConnections -= 1
+                logger.error("Opening new connection for pool failed: \(String(reflecting: error))")
+                return eventLoop.makeFailedFuture(error)
+            }.cascadeFailure(to: promise)
+        }
+        
+        return promise.futureResult
     }
     
     /// Releases a connection back to the pool. Use with `requestConnection()`.
@@ -242,40 +255,37 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     ///     - connection: Connection to release back to the pool.
     ///     - logger: For trace and debug logs.
     public func releaseConnection(_ connection: Source.Connection, logger: Logger) {
-        // dispatch to event loop thread if necessary
-        guard self.eventLoop.inEventLoop else {
-            return self.eventLoop.execute {
-                self.releaseConnection(connection, logger: logger)
-            }
+        if self.eventLoop.inEventLoop {
+            self._releaseConnection0(connection, logger: logger)
+        } else {
+            self.eventLoop.execute { self._releaseConnection0(connection, logger: logger) }
         }
+    }
+    
+    private func _releaseConnection0(_ connection: Source.Connection, logger: Logger) {
+        self.eventLoop.assertInEventLoop()
         
-        // synchronize access to available / active connection checks
+        // If the pool has shut down, just close the connection and return
         guard !self.didShutdown else {
-            // this pool is closed and we are responsible for closing all
-            // of our connections
-            _ = connection.close()
+            if !connection.isClosed {
+                _ = connection.close()
+            }
             return
         }
-
-        // add this connection back to the list of available
-        logger.trace("Releasing connection")
+        
+        // Push the connection onto the end of the available list so it's the first one to get used
+        // on the next request.
+        logger.trace("Releasing pool connection on \(self.eventLoop.description), \(self.available.count + (connection.isClosed ? 0 : 1)) connnections available.")
         self.available.append(connection)
-
-        // now that we know a new connection is available, we should
-        // take this chance to fulfill one of the waiters
-        let waiter: (Logger, EventLoopPromise<Source.Connection>)?
-        if !self.waiters.isEmpty {
-            waiter = self.waiters.removeFirst()
-        } else {
-            waiter = nil
-        }
-
-        // if there is a waiter, request a connection for it
-        if let (logger, promise) = waiter {
-            logger.debug("Fulfilling connection waitlist request")
-            self.requestConnection(
-                logger: logger
-            ).cascade(to: promise)
+        
+        // For as long as there are connections available, try to dequeue waiters. Even if the available
+        // connection(s) are closed, the request logic will try to open new ones.
+        while !self.available.isEmpty, !self.waiters.isEmpty {
+            let waiter = self.waiters.removeFirst()
+            
+            logger.debug("Servicing connection waitlist item with id \(waiter.key)")
+            waiter.value.timeoutTask.cancel()
+            self._requestConnection0(logger: waiter.value.logger).cascade(to: waiter.value.promise)
         }
     }
     
@@ -288,32 +298,35 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     ///
     /// Connection pools must be closed before they deinitialize.
     public func close() -> EventLoopFuture<Void> {
-        // dispatch to event loop thread if necessary
-        guard self.eventLoop.inEventLoop else {
-            return self.eventLoop.flatSubmit {
-                return self.close()
-            }
+        if self.eventLoop.inEventLoop {
+            return self._close0()
+        } else {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            self.eventLoop.execute { self._close0().cascade(to: promise) }
+            return promise.futureResult
         }
+    }
+    
+    private func _close0() -> EventLoopFuture<Void> {
+        self.eventLoop.assertInEventLoop()
         
-        // check to make sure we aren't double closing
         guard !self.didShutdown else {
-            return self.eventLoop.makeSucceededFuture(())
+            return self.eventLoop.makeSucceededVoidFuture()
         }
         self.didShutdown = true
-        self.logger.trace("Connection pool storage shutting down, closing all available connections on this event loop")
-
-        // no locks needed as this can only happen once
+        self.logger.trace("Connection pool shutting down - closing all available connections on this event loop")
+        
+        for (_, waiter) in self.waiters {
+            waiter.timeoutTask.cancel()
+            waiter.promise.fail(ConnectionPoolError.shutdown)
+        }
+        self.waiters.removeAll()
+        
         return self.available.map {
-            $0.close().map {
-                self.activeConnections -= 1
-            }
+            $0.close()
         }.flatten(on: self.eventLoop).map {
-            // inform any waiters that they will never be receiving a connection
-            while let (_, promise) = self.waiters.popFirst() {
-                promise.fail(ConnectionPoolError.shutdown)
-            }
-            // reset any variables to free up memory
-            self.available = .init()
+            self.activeConnections = 0
+            self.available.removeAll()
         }
     }
     

--- a/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
@@ -35,7 +35,7 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
     public let eventLoop: EventLoop
     
     /// ID generator
-    private var idGenerator = ManagedAtomic(0)
+    private let idGenerator = ManagedAtomic(0)
     
     /// All currently available connections.
     ///


### PR DESCRIPTION
## Overview

This is a temporary stopgap measure to clean up some of the more extant issues with the existing implementation, pending the integration of a much more robust and advanced connection pool solution.

While technically there is no change in the public API surface, this is nonetheless being marked as semver-minor due to the significant changes in behavior. This PR has already revealed a query ordering bug in the Fluent benchmarks just by behaving more correctly.

This _should_ hopefully fix the issue described in #101, but I haven't been able to locally reproduce the race condition despite being fairly sure as to its cause, so I can't verify.

## More details

- Now uses `Deque` instead of the obsolete `CircularBuffer` for tracking available connections
- Now uses an `OrderedDictionary` and numeric waiter IDs to track waitlists rather than the obsolete `CircularBuffer`
- Checking for on-EventLoop execution is now handled more idomatically
- Queries are now always served in order instead of new queries getting priority over those already on the waitlist when a new connection becomes available
- Removing completed waiters from the waitlist and cancelling their timeouts is now considerably more reliable
- If more than one connection has become available when a connection is released, multiple waiters are now serviced immediately
- Waiters that are still waiting during pool shutdown no longer emit spurious request timeout logs
- The time taken to establish a new database connection (if needed) now counts against a waiter's timeout duration (making the duration much more accurate)