### PR TITLE
Fix typo in connection request error message

### DIFF
--- a/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
@@ -201,7 +201,7 @@ public final class EventLoopConnectionPool<Source> where Source: ConnectionPoolS
                 return
             }
             logger.error("""
-                Connection request (ID \(waiterId) timed out. This might indicate a connection deadlock in \
+                Connection request (ID \(waiterId)) timed out. This might indicate a connection deadlock in \
                 your application. If you have long-running requests, consider increasing your connection timeout.
                 """)
             promise.fail(ConnectionPoolTimeoutError.connectionRequestTimeout)


### PR DESCRIPTION
There's a parenthesis missing in the connection request error message.

This fixes https://github.com/vapor/async-kit/issues/107.