### PR TITLE
feat: Enable WASM compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,5 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     secrets: inherit
+    with:
+      with_wasm: true

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,9 @@ let package = Package(
         .library(name: "AsyncKit", targets: ["AsyncKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.61.0"),
+        // TODO: SM: Update swift-nio version once NIOAsyncRuntime is available from swift-nio
+        // .package(url: "https://github.com/apple/swift-nio.git", from: "2.89.0"),
+        .package(url: "https://github.com/PassiveLogic/swift-nio.git", branch: "feat/addNIOAsyncRuntimeForWasm"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.5"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.1.0"),
@@ -35,6 +37,8 @@ let package = Package(
             name: "AsyncKitTests",
             dependencies: [
                 .target(name: "AsyncKit"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/Sources/AsyncKit/Exports.swift
+++ b/Sources/AsyncKit/Exports.swift
@@ -1,6 +1,10 @@
+#if canImport(NIOEmbedded) && !os(WASI)
 @_documentation(visibility: internal) @_exported import class NIOEmbedded.EmbeddedEventLoop
+#endif
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoop
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoopGroup
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
 @_documentation(visibility: internal) @_exported import struct NIOCore.EventLoopPromise
+#if canImport(NIOPosix) && !os(WASI)
 @_documentation(visibility: internal) @_exported import class NIOPosix.MultiThreadedEventLoopGroup
+#endif

--- a/Tests/AsyncKitTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncKitTests/ConnectionPoolTests.swift
@@ -4,6 +4,7 @@ import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import class NIOPosix.MultiThreadedEventLoopGroup
 import XCTest
 
 final class ConnectionPoolTests: AsyncKitTestCase {


### PR DESCRIPTION
# Summary

This PR adds support for compiling async-kit to wasm using the [Swift SDK for WebAssembly](https://www.swift.org/documentation/articles/wasm-getting-started.html).

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by a company called PassiveLogic to enable broad support for Swift WebAssembly.

# Details

- Enables WASM compilation
- Adds configuration to compile WASM in CI
- Introduces conditional dependency on DispatchAsync for WASI platforms only, to work around the missing `Dispatch` support in the Swift SDK for WebAssembly
- Removes all imports for `NIOEmbedded` and `NIOPosix` from the `AsyncKit` target. These imports are only used in the test target.
- Update swift-nio dependency to a version that supports the WASI platform.

# Testing done

- [x] Verified unit tests still pass
- [x] Verified no new warnings are created
- [x] Verified `swift build --swift-sdk swift-6.3-DEVELOPMENT-SNAPSHOT-2025-12-07-a_wasm --target AsyncKit` completes without errors. This is the latest daily snapshot of the swift toolchain.
- [x] Verified a third-party executable can build this library as part of a larger wasm executable, and run sqlite in the browser.
- [x] Verified these changes compile in CI. See https://github.com/PassiveLogic/async-kit/actions/runs/20180458445/job/57939351648?pr=1.

# Usage notes

The current Swift 6.2.x breaks certain wasm executors that make testing wasm executables like this impossible. To fully test this running in the browser, recommend using Swift 6.3.x or later.

# Impact Risk

If anyone depends solely on the removed exports for their documentation, their builds may break. But since NIOPosix and NIOEmbedded aren't used in the target anymore, it makes sense to remove those exports from the `AsyncKit` target.