### PR TITLE
Fix for "missing import" warnings in other packages

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,20 @@ on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
 
-env:
-  LOG_LEVEL: info
-  SWIFT_DETERMINISTIC_HASHING: 1
-
 jobs:
   unit-tests:
+    permissions:
+      contents: read
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    secrets: inherit
+    with:
+      with_android: true
+      with_musl: true
+      with_release_mode_testing: true
+
+  submit-dependencies:
+    permissions:
+      contents: write
+    if: ${{ github.event_name == 'push' }}
+    uses: vapor/ci/.github/workflows/submit-deps.yml@main
     secrets: inherit

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
@@ -13,10 +13,10 @@ let package = Package(
         .library(name: "AsyncKit", targets: ["AsyncKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.61.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.5"),
-        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.95.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.1"),
     ],
     targets: [
         .target(
@@ -38,14 +38,15 @@ let package = Package(
             ],
             swiftSettings: swiftSettings
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("ConciseMagicFile"),
-    .enableUpcomingFeature("ForwardTrailingClosures"),
-    //.enableUpcomingFeature("DisableOutwardActorInference"),
+    //.enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
-    //.enableExperimentalFeature("StrictConcurrency=complete"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    //.enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
 ] }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 <a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/async-kit/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/async-kit/test.yml?event=push&style=plastic&logo=github&label=test&logoColor=%23ccc" alt="Continuous Integration"></a>
-<a href="https://codecov.io/github/vapor/async-kit"><img src="https://img.shields.io/codecov/c/github/vapor/async-kit?style=plastic&logo=codecov&label=Codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
+<a href="https://codecov.io/github/vapor/async-kit"><img src="https://img.shields.io/codecov/c/github/vapor/async-kit?style=plastic&logo=codecov&label=Codecov" alt="Code Coverage"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift60up.svg" alt="Swift 6.0+"></a>
 </p>
 
 <br>

--- a/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
+++ b/Sources/AsyncKit/ConnectionPool/EventLoopConnectionPool.swift
@@ -1,5 +1,7 @@
 import Atomics
 import Collections
+import DequeModule
+import OrderedCollections
 import NIOCore
 import struct Foundation.UUID
 import struct Logging.Logger

--- a/Sources/AsyncKit/Docs.docc/Resources/vapor-asynckit-logo.svg
+++ b/Sources/AsyncKit/Docs.docc/Resources/vapor-asynckit-logo.svg
@@ -1,21 +1,27 @@
 <svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" id="technology">
   <defs>
   <style>
-    body[data-color-scheme="dark"]{--color-logo-shape:#000; --color-logo-base:#fff;}
-    @media(prefers-color-scheme:dark){:root{--color-logo-shape:#000; --color-logo-base:#fff;}}
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
   </style>
-  <path id="d" d="M6,47l58-47,58,47-58,45z"/>
-  <path id="s" d="M6,47v12l58,45v-12z"/>
-  <path id="h" d="M84,37l-13.5,2.8,3.6-10.6c1.6-4.75-7.54-6.7-9.15-2l-3.6,10.6-9.9-7.8c-4.36-3.45-11.1,1.8-6.7,5.3l9.9,7.8-13.5,2.8c-6,1.26-3.54,8.5,2.5,7.2l13.5-2.8-3.6,10.6c-1.54,4.54,7.45,7,9.15,2l3.6-10.6,9.9,7.8c4.4,3.46,11.1-1.8,6.7-5.3l-9.9-7.8,13.5-2.8c6-1.25,3.5-8.5-2.5-7.2z"/>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m 84,37 -13.5,2.8 3.6,-10.6 c 1.6,-4.8 -7.5,-6.7 -9.2,-2 l -3.6,10.6 -9.9,-7.8 c -4.4,-3.5 -11.1,1.8 -6.7,5.3 l 9.9,7.8 -13.5,2.8 c -6,1.3 -3.5,8.5 2.5,7.2 l 13.5,-2.8 -3.6,10.6 c -1.5,4.5 7.5,7 9.2,2 l 3.6,-10.6 9.9,7.8 c 4.4,3.5 11.1,-1.8 6.7,-5.3 l -9.9,-7.8 13.5,-2.8 c 6,-1.2 3.5,-8.5 -2.5,-7.2 z"/>
+  <mask id="fade"><path d="m84,37-13.5,2.8,3.6-10.6c1.6-4.8-7.5-6.7-9.2-2l-3.6,10.6-9.9-7.8c-4.4-3.5-11.1,1.8-6.7,5.3l9.9,7.8-13.5,2.8c-6,1.3-3.5,8.5,2.5,7.2l13.5-2.8-3.6,10.6c-1.5,4.5,7.5,7,9.2,2l3.6-10.6,9.9,7.8c4.4,3.5,11.1-1.8,6.7-5.3l-9.9-7.8,13.5-2.8c6-1.2,3.5-8.5-2.5-7.2zM6,47l58-47,58,47-58,45zm116,0v12l-58,45v-12zm0,12v12l-58,45v-12zm0,12v12l-58,45v-12zM6,47v12l58,45v-12zm0,12v12l58,45v-12zm0,12v12l58,45v-12z" style="fill:#fff"/></mask>
   </defs>
-  <use href="#s" fill="#38c0ff" y="24"/>
-  <use href="#s" fill="#6bd0ff" y="12"/>
-  <use href="#s" fill="#9ee0ff"/>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
   <g transform="matrix(-1 0 0 1 128 0)">
-    <use href="#s" fill="#e438ff" y="24"/>
-    <use href="#s" fill="#eb6bff" y="12"/>
-    <use href="#s" fill="#f29eff"/>
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
   </g>
-  <use href="#d" style="fill:var(--color-logo-base, #000)"/>
-  <use href="#h" style="fill:var(--color-logo-shape,#fff)"/>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <rect width="128" height="128" mask="url(#fade)" style="fill: var(--color-logo-shape, #ffffff); opacity: .45;"/>
 </svg>

--- a/Sources/AsyncKit/Docs.docc/theme-settings.json
+++ b/Sources/AsyncKit/Docs.docc/theme-settings.json
@@ -1,6 +1,6 @@
 {
   "theme": {
-    "aside": { "border-radius": "6px", "border-style": "double", "border-width": "3px" },
+    "aside": { "border-radius": "16px", "border-width": "3px", "border-style": "double" },
     "border-radius": "0",
     "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
@@ -8,9 +8,9 @@
       "asynckit": "#808080",
       "documentation-intro-fill":  "radial-gradient(circle at top, var(--color-asynckit) 30%, #000 100%)",
       "documentation-intro-accent": "var(--color-asynckit)",
-      "documentation-intro-eyebrow": "white",
+      "hero-eyebrow": "white",
       "documentation-intro-figure": "white",
-      "documentation-intro-title": "white",
+      "hero-title": "white",
       "logo-base":  { "dark": "#fff", "light": "#000" },
       "logo-shape": { "dark": "#000", "light": "#fff" },
       "fill":       { "dark": "#000", "light": "#fff" }

--- a/Tests/AsyncKitTests/AsyncConnectionPoolTests.swift
+++ b/Tests/AsyncKitTests/AsyncConnectionPoolTests.swift
@@ -1,59 +1,61 @@
-import Atomics
 @preconcurrency import AsyncKit
-import XCTest
-import NIOConcurrencyHelpers
+import Atomics
 import Logging
+import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import Testing
 
-final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
-    func testPooling() async throws {
+@Suite
+struct AsyncConnectionPoolTests {
+    @Test
+    func pooling() async throws {
         let foo = FooDatabase()
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 2,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
         
         // make two connections
         let connA = try await pool.requestConnection().get()
-        XCTAssertEqual(connA.isClosed, false)
+        #expect(!connA.isClosed)
         let connB = try await pool.requestConnection().get()
-        XCTAssertEqual(connB.isClosed, false)
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
-        
+        #expect(!connB.isClosed)
+        #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
+
         // try to make a third, but pool only supports 2
         let futureC = pool.requestConnection()
         let connC = ManagedAtomic<FooConnection?>(nil)
         futureC.whenSuccess { connC.store($0, ordering: .relaxed) }
-        XCTAssertNil(connC.load(ordering: .relaxed))
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
-        
+        #expect(connC.load(ordering: .relaxed) == nil)
+        #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
+
         // release one of the connections, allowing the third to be made
         pool.releaseConnection(connB)
         let connCRet = try await futureC.get()
-        XCTAssertNotNil(connC.load(ordering: .relaxed))
-        XCTAssert(connC.load(ordering: .relaxed) === connB)
-        XCTAssert(connCRet === connC.load(ordering: .relaxed))
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
-        
+        #expect(connC.load(ordering: .relaxed) != nil)
+        #expect(connC.load(ordering: .relaxed) === connB)
+        #expect(connCRet === connC.load(ordering: .relaxed))
+        #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
+
         // try to make a third again, with two active
         let futureD = pool.requestConnection()
         let connD = ManagedAtomic<FooConnection?>(nil)
         futureD.whenSuccess { connD.store($0, ordering: .relaxed) }
-        XCTAssertNil(connD.load(ordering: .relaxed))
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
-        
+        #expect(connD.load(ordering: .relaxed) == nil)
+        #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
+
         // this time, close the connection before releasing it
         try await connCRet.close().get()
         pool.releaseConnection(connC.load(ordering: .relaxed)!)
         let connDRet = try await futureD.get()
-        XCTAssert(connD.load(ordering: .relaxed) !== connB)
-        XCTAssert(connDRet === connD.load(ordering: .relaxed))
-        XCTAssertEqual(connD.load(ordering: .relaxed)?.isClosed, false)
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 3)
-        
-        try! await pool.close().get()
+        #expect(connD.load(ordering: .relaxed) !== connB)
+        #expect(connDRet === connD.load(ordering: .relaxed))
+        #expect(connD.load(ordering: .relaxed)?.isClosed == false)
+        #expect(foo.connectionsCreated.load(ordering: .relaxed) == 3)
+
+        try await pool.close().get()
     }
 
     func testFIFOWaiters() async throws {
@@ -61,7 +63,7 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 1,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
 
         // * User A makes a request for a connection, gets connection number 1.
@@ -79,16 +81,16 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
 
         // * User B gets his connection
         let b = try await b_1.get()
-        XCTAssert(a === b)
+        #expect(a === b)
 
         // * User B releases his connection
         pool.releaseConnection(b)
 
         // * User A's second connection request is fulfilled
         let c = try await a_2.get()
-        XCTAssert(a === c)
-        
-        try! await pool.close().get()
+        #expect(a === c)
+
+        try await pool.close().get()
     }
 
     func testConnectError() async throws {
@@ -96,25 +98,15 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let pool = EventLoopConnectionPool(
             source: db,
             maxConnections: 1,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
 
-        do {
-            _ = try await pool.requestConnection().get()
-            XCTFail("should not have created connection")
-        } catch _ as ErrorDatabase.Error {
-            // pass
-        }
+        await #expect(throws: ErrorDatabase.Error.self) { try await pool.requestConnection().get() }
 
         // test that we can still make another request even after a failed request
-        do {
-            _ = try await pool.requestConnection().get()
-            XCTFail("should not have created connection")
-        } catch _ as ErrorDatabase.Error {
-            // pass
-        }
-        
-        try! await pool.close().get()
+        await #expect(throws: ErrorDatabase.Error.self) { try await pool.requestConnection().get() }
+
+        try await pool.close().get()
     }
 
     func testPoolClose() async throws {
@@ -122,7 +114,7 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 1,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
         let _ = try await pool.requestConnection().get()
         let b = pool.requestConnection()
@@ -131,20 +123,10 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let c = pool.requestConnection()
 
         // check that waiters are failed
-        do {
-            _ = try await b.get()
-            XCTFail("should not have created connection")
-        } catch ConnectionPoolError.shutdown {
-            // pass
-        }
+        await #expect(throws: ConnectionPoolError.shutdown) { try await b.get() }
 
         // check that new requests fail
-        do {
-            _ = try await c.get()
-            XCTFail("should not have created connection")
-        } catch ConnectionPoolError.shutdown {
-            // pass
-        }
+        await #expect(throws: ConnectionPoolError.shutdown) { try await c.get() }
     }
     
     func testGracefulShutdownAsync() async throws {
@@ -152,19 +134,12 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 2,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
         
         try await pool.shutdownAsync()
-        var errorCaught = false
-        
-        do {
-            try await pool.shutdownAsync()
-        } catch {
-            errorCaught = true
-            XCTAssertEqual(error as? ConnectionPoolError, ConnectionPoolError.shutdown)
-        }
-        XCTAssertTrue(errorCaught)
+
+        await #expect(throws: ConnectionPoolError.shutdown) { try await pool.shutdownAsync() }
     }
 
     func testShutdownWithHeldConnection() async throws {
@@ -172,27 +147,18 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 2,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
         
         let connection = try await pool.requestConnection().get()
         
         try await pool.shutdownAsync()
-        var errorCaught = false
-        
-        do {
-            try await pool.shutdownAsync()
-        } catch {
-            errorCaught = true
-            XCTAssertEqual(error as? ConnectionPoolError, ConnectionPoolError.shutdown)
-        }
-        XCTAssertTrue(errorCaught)
-        
-        let result1 = try await connection.eventLoop.submit { connection.isClosed }.get()
-        XCTAssertFalse(result1)
+
+        await #expect(throws: ConnectionPoolError.shutdown) { try await pool.shutdownAsync() }
+
+        #expect(!(try await connection.eventLoop.submit { connection.isClosed }.get()))
         pool.releaseConnection(connection)
-        let result2 = try await connection.eventLoop.submit { connection.isClosed }.get()
-        XCTAssertTrue(result2)
+        #expect(try await connection.eventLoop.submit { connection.isClosed }.get())
     }
 
     func testEventLoopDelegation() async throws {
@@ -200,21 +166,17 @@ final class AsyncConnectionPoolTests: AsyncKitAsyncTestCase {
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 1,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
         
         for _ in 0..<500 {
-            let eventLoop = self.group.any()
-            let a = pool.requestConnection(
-                on: eventLoop
-            ).map { conn in
-                XCTAssertTrue(eventLoop.inEventLoop)
+            let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+            let a = pool.requestConnection(on: eventLoop).map { conn in
+                #expect(eventLoop.inEventLoop)
                 pool.releaseConnection(conn)
             }
-            let b = pool.requestConnection(
-                on: eventLoop
-            ).map { conn in
-                XCTAssertTrue(eventLoop.inEventLoop)
+            let b = pool.requestConnection(on: eventLoop).map { conn in
+                #expect(eventLoop.inEventLoop)
                 pool.releaseConnection(conn)
             }
             _ = try await a.and(b).get()

--- a/Tests/AsyncKitTests/AsyncKitTestsCommon.swift
+++ b/Tests/AsyncKitTests/AsyncKitTestsCommon.swift
@@ -17,46 +17,8 @@ func env(_ name: String) -> String? {
 let isLoggingConfigured: Bool = {
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .info
+        handler.logLevel = env("LOG_LEVEL").flatMap { .init(rawValue: $0) } ?? .info
         return handler
     }
     return true
 }()
-
-class AsyncKitTestCase: XCTestCase {
-    var group: (any EventLoopGroup)!
-    var eventLoop: any EventLoop { self.group.any() }
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    }
-
-    override func tearDownWithError() throws {
-        try self.group.syncShutdownGracefully()
-        self.group = nil
-        try super.tearDownWithError()
-    }
-
-    override class func setUp() {
-        super.setUp()
-        XCTAssertTrue(isLoggingConfigured)
-    }
-}
-
-class AsyncKitAsyncTestCase: XCTestCase {
-    var group: (any EventLoopGroup)!
-    var eventLoop: any EventLoop { self.group.any() }
-
-    override func setUp() async throws {
-        try await super.setUp()
-        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        XCTAssertTrue(isLoggingConfigured)
-    }
-    
-    override func tearDown() async throws {
-        try await self.group.shutdownGracefully()
-        self.group = nil
-        try await super.tearDown()
-    }
-}

--- a/Tests/AsyncKitTests/Collection+FlattenTests.swift
+++ b/Tests/AsyncKitTests/Collection+FlattenTests.swift
@@ -1,48 +1,53 @@
 import AsyncKit
-import XCTest
 import NIOCore
+import Testing
 
-final class CollectionFlattenTests: AsyncKitTestCase {
-    func testELFlatten()throws {
+@Suite
+struct CollectionFlattenTests {
+    @Test
+    func elFlatten() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let futures = [
-            self.eventLoop.makeSucceededFuture(1),
-            self.eventLoop.makeSucceededFuture(2),
-            self.eventLoop.makeSucceededFuture(3),
-            self.eventLoop.makeSucceededFuture(4),
-            self.eventLoop.makeSucceededFuture(5),
-            self.eventLoop.makeSucceededFuture(6),
-            self.eventLoop.makeSucceededFuture(7)
+            eventLoop.makeSucceededFuture(1),
+            eventLoop.makeSucceededFuture(2),
+            eventLoop.makeSucceededFuture(3),
+            eventLoop.makeSucceededFuture(4),
+            eventLoop.makeSucceededFuture(5),
+            eventLoop.makeSucceededFuture(6),
+            eventLoop.makeSucceededFuture(7)
         ]
         
-        let flattened = self.eventLoop.flatten(futures)
-        try XCTAssertEqual(flattened.wait(), [1, 2, 3, 4, 5, 6, 7])
-        
+        let flattened = eventLoop.flatten(futures)
+        #expect(try await flattened.get() == [1, 2, 3, 4, 5, 6, 7])
+
         let voids = [
-            self.eventLoop.makeSucceededFuture(()),
-            self.eventLoop.makeSucceededFuture(()),
-            self.eventLoop.makeSucceededFuture(()),
-            self.eventLoop.makeSucceededFuture(()),
-            self.eventLoop.makeSucceededFuture(()),
-            self.eventLoop.makeSucceededFuture(()),
-            self.eventLoop.makeSucceededFuture(())
+            eventLoop.makeSucceededFuture(()),
+            eventLoop.makeSucceededFuture(()),
+            eventLoop.makeSucceededFuture(()),
+            eventLoop.makeSucceededFuture(()),
+            eventLoop.makeSucceededFuture(()),
+            eventLoop.makeSucceededFuture(()),
+            eventLoop.makeSucceededFuture(())
         ]
         
-        let void = self.eventLoop.flatten(voids)
-        try XCTAssert(void.wait() == ())
+        let void = eventLoop.flatten(voids)
+        #expect(try await void.get() == ())
     }
     
-    func testCollectionFlatten()throws {
+    @Test
+    func collectionFlatten() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let futures = [
-            self.eventLoop.makeSucceededFuture(1),
-            self.eventLoop.makeSucceededFuture(2),
-            self.eventLoop.makeSucceededFuture(3),
-            self.eventLoop.makeSucceededFuture(4),
-            self.eventLoop.makeSucceededFuture(5),
-            self.eventLoop.makeSucceededFuture(6),
-            self.eventLoop.makeSucceededFuture(7)
+            eventLoop.makeSucceededFuture(1),
+            eventLoop.makeSucceededFuture(2),
+            eventLoop.makeSucceededFuture(3),
+            eventLoop.makeSucceededFuture(4),
+            eventLoop.makeSucceededFuture(5),
+            eventLoop.makeSucceededFuture(6),
+            eventLoop.makeSucceededFuture(7)
         ]
         
-        let flattened = futures.flatten(on: self.eventLoop)
-        try XCTAssertEqual(flattened.wait(), [1, 2, 3, 4, 5, 6, 7])
+        let flattened = futures.flatten(on: eventLoop)
+        #expect(try await flattened.get() == [1, 2, 3, 4, 5, 6, 7])
     }
 }

--- a/Tests/AsyncKitTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncKitTests/ConnectionPoolTests.swift
@@ -4,58 +4,66 @@ import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
-import XCTest
+import Testing
 
-final class ConnectionPoolTests: AsyncKitTestCase {
-    func testPooling() throws {
+@Suite
+struct ConnectionPoolTests {
+    @Test
+    func pooling() async throws {
         let foo = FooDatabase()
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 2,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
-        defer { try! pool.close().wait() }
 
-        // make two connections
-        let connA = try pool.requestConnection().wait()
-        XCTAssertEqual(connA.isClosed, false)
-        let connB = try pool.requestConnection().wait()
-        XCTAssertEqual(connB.isClosed, false)
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
+        do {
+            // make two connections
+            let connA = try await pool.requestConnection().get()
+            #expect(!connA.isClosed)
+            let connB = try await pool.requestConnection().get()
+            #expect(!connB.isClosed)
+            #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
 
-        // try to make a third, but pool only supports 2
-        let futureC = pool.requestConnection()
-        let connC = ManagedAtomic<FooConnection?>(nil)
-        futureC.whenSuccess { connC.store($0, ordering: .relaxed) }
-        XCTAssertNil(connC.load(ordering: .relaxed))
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
+            // try to make a third, but pool only supports 2
+            let futureC = pool.requestConnection()
+            let connC = ManagedAtomic<FooConnection?>(nil)
+            futureC.whenSuccess { connC.store($0, ordering: .relaxed) }
+            #expect(connC.load(ordering: .relaxed) == nil)
+            #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
 
-        // release one of the connections, allowing the third to be made
-        pool.releaseConnection(connB)
-        let connCRet = try futureC.wait()
-        XCTAssertNotNil(connC.load(ordering: .relaxed))
-        XCTAssert(connC.load(ordering: .relaxed) === connB)
-        XCTAssert(connCRet === connC.load(ordering: .relaxed))
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
+            // release one of the connections, allowing the third to be made
+            pool.releaseConnection(connB)
+            let connCRet = try await futureC.get()
+            #expect(connC.load(ordering: .relaxed) === connB)
+            #expect(connCRet === connC.load(ordering: .relaxed))
+            #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
 
-        // try to make a third again, with two active
-        let futureD = pool.requestConnection()
-        let connD = ManagedAtomic<FooConnection?>(nil)
-        futureD.whenSuccess { connD.store($0, ordering: .relaxed) }
-        XCTAssertNil(connD.load(ordering: .relaxed))
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 2)
+            // try to make a third again, with two active
+            let futureD = pool.requestConnection()
+            let connD = ManagedAtomic<FooConnection?>(nil)
+            futureD.whenSuccess { connD.store($0, ordering: .relaxed) }
+            #expect(connD.load(ordering: .relaxed) == nil)
+            #expect(foo.connectionsCreated.load(ordering: .relaxed) == 2)
 
-        // this time, close the connection before releasing it
-        try connCRet.close().wait()
-        pool.releaseConnection(connC.load(ordering: .relaxed)!)
-        let connDRet = try futureD.wait()
-        XCTAssert(connD.load(ordering: .relaxed) !== connB)
-        XCTAssert(connDRet === connD.load(ordering: .relaxed))
-        XCTAssertEqual(connD.load(ordering: .relaxed)?.isClosed, false)
-        XCTAssertEqual(foo.connectionsCreated.load(ordering: .relaxed), 3)
+            // this time, close the connection before releasing it
+            try await connCRet.close().get()
+            pool.releaseConnection(connC.load(ordering: .relaxed)!)
+            let connDRet = try await futureD.get()
+            #expect(connD.load(ordering: .relaxed) !== connB)
+            #expect(connDRet === connD.load(ordering: .relaxed))
+            #expect(connD.load(ordering: .relaxed)?.isClosed == false)
+            #expect(foo.connectionsCreated.load(ordering: .relaxed) == 3)
+
+            try await pool.close().get()
+        } catch {
+            try? await pool.close().get()
+            throw error
+        }
     }
 
-    func testConnectionPruning() throws {
+    @Test
+    func connectionPruning() async throws {
         let foo = FooDatabase()
         let pool = EventLoopConnectionPool(
             source: foo,
@@ -65,150 +73,146 @@ final class ConnectionPoolTests: AsyncKitTestCase {
             on: MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
         )
 
-        defer { try! pool.close().wait() }
+        do {
+            let connA = try await pool.requestConnection().get()
 
-        let connA = try pool.requestConnection().wait()
+            let anotherConnection1 = try await pool.requestConnection().get()
+            let anotherConnection2 = try await pool.requestConnection().get()
 
-        let anotherConnection1 = try pool.requestConnection().wait()
-        let anotherConnection2 = try pool.requestConnection().wait()
+            pool.releaseConnection(connA)
 
-        pool.releaseConnection(connA)
+            let connA1 = try await pool.requestConnection().get()
+            #expect(connA === connA1)
+            pool.releaseConnection(connA1)
 
-        let connA1 = try pool.requestConnection().wait()
-        XCTAssert(connA === connA1)
-        pool.releaseConnection(connA1)
+            // Keeping connection alive by using it and closing it
+            for _ in 0..<3 {
+                try await Task.sleep(nanoseconds: 200_000_000)
+                let connA2 = try await pool.requestConnection().get()
+                #expect(connA === connA2)
+                pool.releaseConnection(connA2)
+            }
 
-        // Keeping connection alive by using it and closing it
-        for _ in 0..<3 {
-            Thread.sleep(forTimeInterval: 0.2)
-            let connA2 = try pool.requestConnection().wait()
-            XCTAssert(connA === connA2)
-            pool.releaseConnection(connA2)
+            pool.releaseConnection(anotherConnection1)
+            pool.releaseConnection(anotherConnection2)
+
+            try await Task.sleep(nanoseconds: 700_000_000)
+            let (knownConnections, activeConnections, openConnections) = try await pool.poolState().get()
+            #expect(knownConnections == 0)
+            #expect(activeConnections == 0)
+            #expect(openConnections == 0)
+
+            let connB = try await pool.requestConnection().get()
+            #expect(connA !== connB)
+            #expect(try await pool.poolState().get().active == 1)
+
+            try await pool.close().get()
+        } catch {
+            try? await pool.close().get()
+            throw error
         }
-
-        pool.releaseConnection(anotherConnection1)
-        pool.releaseConnection(anotherConnection2)
-
-        Thread.sleep(forTimeInterval: 0.7)
-        let (knownConnections, activeConnections, openConnections) = try pool.poolState().wait()
-        XCTAssertEqual(knownConnections, 0)
-        XCTAssertEqual(activeConnections, 0)
-        XCTAssertEqual(openConnections, 0)
-
-        let connB = try pool.requestConnection().wait()
-        XCTAssert(connA !== connB)
-        let newActiveConnections = try pool.poolState().wait().active
-        XCTAssertEqual(newActiveConnections, 1)
     }
 
-    func testFIFOWaiters() throws {
+    @Test
+    func fifoWaiters() async throws {
         let foo = FooDatabase()
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 1,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
-        defer { try! pool.close().wait() }
 
-        // * User A makes a request for a connection, gets connection number 1.
-        let a_1 = pool.requestConnection()
-        let a = try a_1.wait()
+        do {
+            // * User A makes a request for a connection, gets connection number 1.
+            let a_1 = pool.requestConnection()
+            let a = try await a_1.get()
 
-        // * User B makes a request for a connection, they are exhausted so he gets a promise.
-        let b_1 = pool.requestConnection()
+            // * User B makes a request for a connection, they are exhausted so he gets a promise.
+            let b_1 = pool.requestConnection()
 
-        // * User A makes another request for a connection, they are still exhausted so he gets a promise.
-        let a_2 = pool.requestConnection()
+            // * User A makes another request for a connection, they are still exhausted so he gets a promise.
+            let a_2 = pool.requestConnection()
 
-        // * User A returns connection number 1. His previous request is fulfilled with connection number 1.
-        pool.releaseConnection(a)
+            // * User A returns connection number 1. His previous request is fulfilled with connection number 1.
+            pool.releaseConnection(a)
 
-        // * User B gets his connection
-        let b = try b_1.wait()
-        XCTAssert(a === b)
+            // * User B gets his connection
+            let b = try await b_1.get()
+            #expect(a === b)
 
-        // * User B releases his connection
-        pool.releaseConnection(b)
+            // * User B releases his connection
+            pool.releaseConnection(b)
 
-        // * User A's second connection request is fulfilled
-        let c = try a_2.wait()
-        XCTAssert(a === c)
+            // * User A's second connection request is fulfilled
+            let c = try await a_2.get()
+            #expect(a === c)
+
+            try await pool.close().get()
+        } catch {
+            try? await pool.close().get()
+            throw error
+        }
     }
 
-    func testConnectError() throws {
+    @Test
+    func connectError() async throws {
         let db = ErrorDatabase()
         let pool = EventLoopConnectionPool(
             source: db,
             maxConnections: 1,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
-        defer { try! pool.close().wait() }
 
         do {
-            _ = try pool.requestConnection().wait()
-            XCTFail("should not have created connection")
-        } catch _ as ErrorDatabase.Error {
-            // pass
-        }
+            await #expect(throws: ErrorDatabase.Error.self) { try await pool.requestConnection().get() }
 
-        // test that we can still make another request even after a failed request
-        do {
-            _ = try pool.requestConnection().wait()
-            XCTFail("should not have created connection")
-        } catch _ as ErrorDatabase.Error {
-            // pass
+            // test that we can still make another request even after a failed request
+            await #expect(throws: ErrorDatabase.Error.self) { try await pool.requestConnection().get() }
+
+            try await pool.close().get()
+        } catch {
+            try? await pool.close().get()
+            throw error
         }
     }
 
-    func testPoolClose() throws {
+    @Test
+    func poolClose() async throws {
         let foo = FooDatabase()
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 1,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
-        let _ = try pool.requestConnection().wait()
+
+        _ = try await pool.requestConnection().get()
         let b = pool.requestConnection()
-        try pool.close().wait()
+        try await pool.close().get()
 
         let c = pool.requestConnection()
 
         // check that waiters are failed
-        do {
-            _ = try b.wait()
-            XCTFail("should not have created connection")
-        } catch ConnectionPoolError.shutdown {
-            // pass
-        }
+        await #expect(throws: ConnectionPoolError.shutdown) { try await b.get() }
 
         // check that new requests fail
-        do {
-            _ = try c.wait()
-            XCTFail("should not have created connection")
-        } catch ConnectionPoolError.shutdown {
-            // pass
-        }
+        await #expect(throws: ConnectionPoolError.shutdown) { try await c.get() }
     }
 
     // https://github.com/vapor/async-kit/issues/63
-    func testDeadlock() {
+    @Test
+    func deadlock() async throws {
         let foo = FooDatabase()
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 1,
             requestTimeout: .milliseconds(100),
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
-        defer { try! pool.close().wait() }
+
         _ = pool.requestConnection()
-        let start = Date()
         let a = pool.requestConnection()
-        XCTAssertThrowsError(try a.wait(), "Connection should have deadlocked and thrown ConnectionPoolTimeoutError.connectionRequestTimeout") { (error) in
-            let interval = Date().timeIntervalSince(start)
-            XCTAssertGreaterThan(interval, 0.1)
-            XCTAssertLessThan(interval, 0.25)
-            XCTAssertEqual(error as? ConnectionPoolTimeoutError, ConnectionPoolTimeoutError.connectionRequestTimeout)
-        }
+        await #expect(throws: ConnectionPoolTimeoutError.connectionRequestTimeout) { try await a.get() }
+        try await pool.close().get()
     }
 
     /*func testPerformance() {
@@ -217,7 +221,7 @@ final class ConnectionPoolTests: AsyncKitTestCase {
         let pool = EventLoopConnectionPool(
             source: foo,
             maxConnections: 3,
-            on: self.group.any()
+            on: NIOSingletons.posixEventLoopGroup.any()
         )
 
         measure {
@@ -244,90 +248,95 @@ final class ConnectionPoolTests: AsyncKitTestCase {
         }
     }*/
 
-    func testThreadSafety() throws {
+    @Test
+    func threadSafety() async throws {
         let foo = FooDatabase()
-        let pool = EventLoopGroupConnectionPool(
+        nonisolated(unsafe) let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 2,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
-        defer { pool.shutdown() }
 
-        var futures: [EventLoopFuture<Void>] = []
+        do {
+            var futures: [EventLoopFuture<Void>] = []
 
-        var eventLoops = group.makeIterator()
-        while let eventLoop = eventLoops.next() {
-            let promise = eventLoop.makePromise(of: Void.self)
-            eventLoop.execute {
-                (0 ..< 1_000).map { i in
-                    return pool.withConnection(on: eventLoop) { conn in
-                        return conn.eventLoop.makeSucceededFuture(i)
-                    }
-                }.flatten(on: eventLoop)
-                    .map { XCTAssertEqual($0.count, 1_000) }
-                    .cascade(to: promise)
+            var eventLoops = NIOSingletons.posixEventLoopGroup.makeIterator()
+            while let eventLoop = eventLoops.next() {
+                let promise = eventLoop.makePromise(of: Void.self)
+                eventLoop.execute {
+                    (0 ..< 1_000).map { i in
+                        pool.withConnection(on: eventLoop) { $0.eventLoop.makeSucceededFuture(i) }
+                    }.flatten(on: eventLoop)
+                        .map { #expect($0.count == 1_000) }
+                        .cascade(to: promise)
+                }
+                futures.append(promise.futureResult)
             }
-            futures.append(promise.futureResult)
-        }
 
-        try futures.flatten(on: group.any()).wait()
+            try await futures.flatten(on: NIOSingletons.posixEventLoopGroup.any()).get()
+
+            try await pool.shutdownAsync()
+        } catch {
+            try? await pool.shutdownAsync()
+            throw error
+        }
     }
 
-    func testGracefulShutdownAsync() throws {
+    // Not clear how to test this with SwiftTesting
+    /*
+    @Test
+    func gracefulShutdownAsync() async throws {
         let foo = FooDatabase()
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 2,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
 
-        let expectation1 = XCTestExpectation(description: "Shutdown completion")
-        let expectation2 = XCTestExpectation(description: "Shutdown completion with error")
-
-        pool.shutdownGracefully {
-            XCTAssertNil($0)
-            expectation1.fulfill()
+        await confirmation("Shutdown completion") { completion in
+            pool.shutdownGracefully {
+                #expect($0 == nil)
+                completion()
+            }
         }
-        XCTWaiter().wait(for: [expectation1], timeout: 5.0)
 
-        pool.shutdownGracefully {
-            XCTAssertEqual($0 as? ConnectionPoolError, ConnectionPoolError.shutdown)
-            expectation2.fulfill()
+        await confirmation("Shutdown completion with error") { completion in
+            pool.shutdownGracefully {
+                #expect($0 as? ConnectionPoolError == ConnectionPoolError.shutdown)
+                completion()
+            }
         }
-        XCTWaiter().wait(for: [expectation2], timeout: 5.0)
     }
+    */
 
-    func testGracefulShutdownSync() throws {
+    @Test
+    func gracefulShutdownSync() async throws {
         let foo = FooDatabase()
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 2,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
 
-        XCTAssertNoThrow(try pool.syncShutdownGracefully())
-        XCTAssertThrowsError(try pool.syncShutdownGracefully()) {
-            XCTAssertEqual($0 as? ConnectionPoolError, ConnectionPoolError.shutdown)
-        }
+        #expect(throws: Never.self) { try pool.syncShutdownGracefully() }
+        #expect(throws: ConnectionPoolError.shutdown) { try pool.syncShutdownGracefully() }
     }
 
-    func testGracefulShutdownWithHeldConnection() throws {
+    func testGracefulShutdownWithHeldConnection() async throws {
         let foo = FooDatabase()
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 2,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
 
-        let connection = try pool.requestConnection().wait()
+        let connection = try await pool.requestConnection().get()
 
-        XCTAssertNoThrow(try pool.syncShutdownGracefully())
-        XCTAssertThrowsError(try pool.syncShutdownGracefully()) {
-            XCTAssertEqual($0 as? ConnectionPoolError, ConnectionPoolError.shutdown)
-        }
-        XCTAssertFalse(try connection.eventLoop.submit { connection.isClosed }.wait())
+        #expect(throws: Never.self) { try pool.syncShutdownGracefully() }
+        #expect(throws: ConnectionPoolError.shutdown) { try pool.syncShutdownGracefully() }
+        #expect(!(try await connection.eventLoop.submit { connection.isClosed }.get()))
         pool.releaseConnection(connection)
-        XCTAssertTrue(try connection.eventLoop.submit { connection.isClosed }.wait())
+        #expect(try await connection.eventLoop.submit { connection.isClosed }.get())
     }
 
     func testEventLoopDelegation() throws {
@@ -335,22 +344,22 @@ final class ConnectionPoolTests: AsyncKitTestCase {
         let pool = EventLoopGroupConnectionPool(
             source: foo,
             maxConnectionsPerEventLoop: 1,
-            on: self.group
+            on: NIOSingletons.posixEventLoopGroup
         )
         defer { pool.shutdown() }
 
         for _ in 0..<500 {
-            let eventLoop = self.group.any()
+            let eventLoop = NIOSingletons.posixEventLoopGroup.any()
             let a = pool.requestConnection(
                 on: eventLoop
             ).map { conn in
-                XCTAssertTrue(eventLoop.inEventLoop)
+                #expect(eventLoop.inEventLoop)
                 pool.releaseConnection(conn)
             }
             let b = pool.requestConnection(
                 on: eventLoop
             ).map { conn in
-                XCTAssertTrue(eventLoop.inEventLoop)
+                #expect(eventLoop.inEventLoop)
                 pool.releaseConnection(conn)
             }
             _ = try a.and(b).wait()
@@ -368,8 +377,8 @@ struct ErrorDatabase: ConnectionPoolSource {
     }
 }
 
-final class FooDatabase: ConnectionPoolSource {
-    var connectionsCreated: ManagedAtomic<Int>
+final class FooDatabase: ConnectionPoolSource, Sendable {
+    let connectionsCreated: ManagedAtomic<Int>
 
     init() {
         self.connectionsCreated = .init(0)

--- a/Tests/AsyncKitTests/EventLoop+ConcurrencyTests.swift
+++ b/Tests/AsyncKitTests/EventLoop+ConcurrencyTests.swift
@@ -1,18 +1,20 @@
-import XCTest
 import AsyncKit
 import NIOCore
+import Testing
 
-final class EventLoopConcurrencyTests: AsyncKitTestCase {
-    func testGroupMakeFutureWithTask() throws {
+@Suite
+struct EventLoopConcurrencyTests {
+    @Test
+    func groupMakeFutureWithTask() async throws {
         @Sendable
         func getOne() async throws -> Int {
             return 1
         }
-        let expectedOne = self.group.makeFutureWithTask {
+        let expectedOne = NIOSingletons.posixEventLoopGroup.makeFutureWithTask {
             try await getOne()
         }
         
-        XCTAssertEqual(try expectedOne.wait(), 1)
+        #expect(try await expectedOne.get() == 1)
     }
 }
 

--- a/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
+++ b/Tests/AsyncKitTests/EventLoopFutureQueueTests.swift
@@ -1,193 +1,199 @@
-import NIOConcurrencyHelpers
 import AsyncKit
-import XCTest
+import Foundation
+import NIOConcurrencyHelpers
 import NIOCore
+import Testing
 
-final class EventLoopFutureQueueTests: AsyncKitTestCase {
-    func testQueue() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+@Suite
+struct EventLoopFutureQueueTests {
+    func testQueue() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         var numbers: [Int] = []
         let lock = NIOLock()
 
         let one = queue.append(generator: {
-            self.eventLoop.slowFuture(1, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
+            eventLoop.slowFuture(1, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
                 lock.withLockVoid { numbers.append(number) }
                 return number
             }
         })
         let two = queue.append(generator: {
-            self.eventLoop.slowFuture(2, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
+            eventLoop.slowFuture(2, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
                 lock.withLockVoid { numbers.append(number) }
                 return number
             }
         })
         let three = queue.append(generator: {
-            self.eventLoop.slowFuture(3, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
+            eventLoop.slowFuture(3, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
                 lock.withLockVoid { numbers.append(number) }
                 return number
             }
         })
         let four = queue.append(generator: {
-            self.eventLoop.slowFuture(4, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
+            eventLoop.slowFuture(4, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
                 lock.withLockVoid { numbers.append(number) }
                 return number
             }
         })
         let five = queue.append(generator: {
-            self.eventLoop.slowFuture(5, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
+            eventLoop.slowFuture(5, sleeping: .random(in: 0.01 ... 0.5)).map { number -> Int in
                 lock.withLockVoid { numbers.append(number) }
                 return number
             }
         })
 
-        try XCTAssertEqual(one.wait(), 1)
-        try XCTAssertEqual(two.wait(), 2)
-        try XCTAssertEqual(three.wait(), 3)
-        try XCTAssertEqual(four.wait(), 4)
-        try XCTAssertEqual(five.wait(), 5)
+        #expect(try await one.get() == 1)
+        #expect(try await two.get() == 2)
+        #expect(try await three.get() == 3)
+        #expect(try await four.get() == 4)
+        #expect(try await five.get() == 5)
 
-        XCTAssertEqual(numbers, [1, 2, 3, 4, 5])
+        #expect(numbers == [1, 2, 3, 4, 5])
     }
 
-    func testAutoclosure() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+    @Test
+    func autoclosure() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         var numbers: [Int] = []
         let lock = NIOLock()
 
-        let one = queue.append(self.eventLoop.slowFuture(1, sleeping: 0.25).map { num in lock.withLockVoid { numbers.append(num) } })
-        let two = queue.append(self.eventLoop.slowFuture(2, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
-        let three = queue.append(self.eventLoop.slowFuture(3, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
-        let four = queue.append(self.eventLoop.slowFuture(4, sleeping: 0.25).map { num in lock.withLockVoid { numbers.append(num) } })
-        let five = queue.append(self.eventLoop.slowFuture(5, sleeping: 0.25).map { num in lock.withLockVoid { numbers.append(num) } })
+        let one = queue.append(eventLoop.slowFuture(1, sleeping: 0.25).map { num in lock.withLockVoid { numbers.append(num) } })
+        let two = queue.append(eventLoop.slowFuture(2, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
+        let three = queue.append(eventLoop.slowFuture(3, sleeping: 0).map { num in lock.withLockVoid { numbers.append(num) } })
+        let four = queue.append(eventLoop.slowFuture(4, sleeping: 0.25).map { num in lock.withLockVoid { numbers.append(num) } })
+        let five = queue.append(eventLoop.slowFuture(5, sleeping: 0.25).map { num in lock.withLockVoid { numbers.append(num) } })
 
-        try XCTAssertNoThrow(one.wait())
-        try XCTAssertNoThrow(two.wait())
-        try XCTAssertNoThrow(three.wait())
-        try XCTAssertNoThrow(four.wait())
-        try XCTAssertNoThrow(five.wait())
+        await #expect(throws: Never.self) { try await one.get() }
+        await #expect(throws: Never.self) { try await two.get() }
+        await #expect(throws: Never.self) { try await three.get() }
+        await #expect(throws: Never.self) { try await four.get() }
+        await #expect(throws: Never.self) { try await five.get() }
 
-        XCTAssertEqual(numbers, [1, 2, 3, 4, 5])
+        #expect(numbers == [1, 2, 3, 4, 5])
     }
 
-    func testContinueOnSucceed() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+    @Test
+    func continueOnSucceed() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
 
-        let one = queue.append(self.eventLoop.slowFuture(1, sleeping: 0.25), runningOn: .success)
-        let two = queue.append(self.eventLoop.slowFuture(2, sleeping: 0), runningOn: .success)
+        let one = queue.append(eventLoop.slowFuture(1, sleeping: 0.25), runningOn: .success)
+        let two = queue.append(eventLoop.slowFuture(2, sleeping: 0), runningOn: .success)
         let fail: EventLoopFuture<Int> = queue.append(
-            self.eventLoop.makeFailedFuture(Failure.nope),
+            eventLoop.makeFailedFuture(Failure.nope),
             runningOn: .success
         )
-        let three = queue.append(self.eventLoop.slowFuture(3, sleeping: 0.25), runningOn: .success)
+        let three = queue.append(eventLoop.slowFuture(3, sleeping: 0.25), runningOn: .success)
 
-        try XCTAssertEqual(one.wait(), 1)
-        try XCTAssertEqual(two.wait(), 2)
+        #expect(try await one.get() == 1)
+        #expect(try await two.get() == 2)
 
-        try XCTAssertThrowsError(fail.wait()) { error in
-            XCTAssertEqual(error as? Failure, .nope)
-        }
-        try XCTAssertThrowsError(three.wait()) { error in
-            guard case let EventLoopFutureQueue.ContinueError.previousError(fail) = error else {
-                return XCTFail("Unexpected error \(error.localizedDescription)")
-            }
-
-            XCTAssertEqual(fail as? Failure, .nope)
-        }
+        await #expect(throws: Failure.nope) { try await fail.get() }
+        await #expect(throws: EventLoopFutureQueue.ContinueError.self) { try await three.get() }
     }
 
-    func testContinueOnFail() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+    @Test
+    func continueOnFail() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
 
         let fail: EventLoopFuture<Int> = queue.append(
-            self.eventLoop.makeFailedFuture(Failure.nope),
+            eventLoop.makeFailedFuture(Failure.nope),
             runningOn: .success
         )
-        let one = queue.append(self.eventLoop.slowFuture(1, sleeping: 0.25), runningOn: .failure)
-        let two = queue.append(self.eventLoop.slowFuture(2, sleeping: 0), runningOn: .success)
-        let three = queue.append(self.eventLoop.slowFuture(3, sleeping: 0.25), runningOn: .failure)
+        let one = queue.append(eventLoop.slowFuture(1, sleeping: 0.25), runningOn: .failure)
+        let two = queue.append(eventLoop.slowFuture(2, sleeping: 0), runningOn: .success)
+        let three = queue.append(eventLoop.slowFuture(3, sleeping: 0.25), runningOn: .failure)
 
-        try XCTAssertEqual(one.wait(), 1)
-        try XCTAssertEqual(two.wait(), 2)
+        #expect(try await one.get() == 1)
+        #expect(try await two.get() == 2)
 
-        try XCTAssertThrowsError(fail.wait()) { error in
-            XCTAssertEqual(error as? Failure, .nope)
-        }
-        try XCTAssertThrowsError(three.wait()) { error in
-            guard case EventLoopFutureQueue.ContinueError.previousSuccess = error else {
-                return XCTFail("Unexpected error \(error.localizedDescription)")
-            }
-        }
+        await #expect(throws: Failure.nope) { try await fail.get() }
+        await #expect(throws: EventLoopFutureQueue.ContinueError.self) { try await three.get() }
     }
-    
-    func testSimpleSequence() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+
+    @Test
+    func simpleSequence() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         let values = [1, 2, 3, 4, 5]
         
-        let all = queue.append(each: values) { self.eventLoop.slowFuture($0, sleeping: 0.25) }
+        let all = queue.append(each: values) { eventLoop.slowFuture($0, sleeping: 0.25) }
 
-        try XCTAssertEqual(all.wait(), [1, 2, 3, 4, 5])
+        #expect(try await all.get() == [1, 2, 3, 4, 5])
     }
     
-    func testVoidReturnSequence() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+    @Test
+    func voidReturnSequence() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         let values = 99..<135
         var output: [Int] = []
-        let all = queue.append(each: values) { v in self.eventLoop.slowFuture((), sleeping: 0).map { output.append(v) } }
+        let all = queue.append(each: values) { v in eventLoop.slowFuture((), sleeping: 0).map { output.append(v) } }
 
-        try XCTAssertNoThrow(all.wait())
-        XCTAssertEqual(Array(values), output)
+        await #expect(throws: Never.self) { try await all.get() }
+        #expect(Array(values) == output)
     }
-    
-    func testSequenceWithFailure() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+
+    @Test
+    func sequenceWithFailure() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         var completedResults: [Int] = []
         
         let all = queue.append(each: [1, 2, 3, 4, 5, 6]) { (v: Int) -> EventLoopFuture<Int> in
             guard v < 3 || v > 5 else {
-                return self.eventLoop.future(error: Failure.nope)
+                return eventLoop.future(error: Failure.nope)
             }
             completedResults.append(v)
-            return self.eventLoop.slowFuture(v, sleeping: 0.25)
+            return eventLoop.slowFuture(v, sleeping: 0.25)
         }
         
-        try XCTAssertThrowsError(all.wait())
-        XCTAssertEqual(completedResults, [1, 2]) // Make sure we didn't run with value 6
+        await #expect(throws: (any Error).self) { try await all.get() }
+        #expect(completedResults == [1, 2]) // Make sure we didn't run with value 6
     }
 
-    func testVoidSequenceWithFailure() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+    @Test
+    func voidSequenceWithFailure() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         let values = 99..<135
         var output: [Int] = []
         let all = queue.append(each: values) { v -> EventLoopFuture<Void> in
             guard v < 104 || v > 110 else {
-                return self.eventLoop.future(error: Failure.nope)
+                return eventLoop.future(error: Failure.nope)
             }
-            return self.eventLoop.slowFuture((), sleeping: 0).map { output.append(v) }
+            return eventLoop.slowFuture((), sleeping: 0).map { output.append(v) }
         }
 
-        try XCTAssertThrowsError(all.wait())
-        XCTAssertEqual(Array(values).prefix(while: { $0 < 104 }), output)
+        await #expect(throws: (any Error).self) { try await all.get() }
+        #expect(Array(values).prefix(while: { $0 < 104 }) == output)
     }
-    
-    func testEmptySequence() throws {
-        let queue = EventLoopFutureQueue(eventLoop: self.eventLoop)
+
+    @Test
+    func emptySequence() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let queue = EventLoopFutureQueue(eventLoop: eventLoop)
         var count = 0
         
         _ = queue.append(onPrevious: .success) { queue.eventLoop.tryFuture { count = 1 } }
         let all = queue.append(each: Array<Int>(), { _ in queue.eventLoop.tryFuture { count = 99 } })
         
-        try XCTAssertNoThrow(all.wait())
-        XCTAssertEqual(count, 1)
+        await #expect(throws: Never.self) { try await all.get() }
+        #expect(count == 1)
     }
 
-    func testContinueErrorPreviousErrorDescription() throws {
+    @Test
+    func continueErrorPreviousErrorDescription() throws {
         let error = EventLoopFutureQueue.ContinueError.previousError(
             EventLoopFutureQueue.ContinueError.previousError(
                 EventLoopFutureQueue.ContinueError.previousError(Failure.nope)
             )
         )
 
-        XCTAssertEqual(error.description, "previousError(nope)")
+        #expect(error.description == "previousError(nope)")
     }
 }
 

--- a/Tests/AsyncKitTests/EventLoopGroup+FutureTests.swift
+++ b/Tests/AsyncKitTests/EventLoopGroup+FutureTests.swift
@@ -1,26 +1,30 @@
 import AsyncKit
-import XCTest
 import NIOCore
+import Testing
 
-final class EventLoopGroupFutureTests: AsyncKitTestCase {
-    func testFutureVoid() throws {
-        try XCTAssertNoThrow(self.group.future().wait())
-        try XCTAssertNoThrow(self.eventLoop.future().wait())
+@Suite
+struct EventLoopGroupFutureTests {
+    @Test
+    func futureVoid() async throws {
+        await #expect(throws: Never.self) { try await NIOSingletons.posixEventLoopGroup.future().get() }
+        await #expect(throws: Never.self) { try await NIOSingletons.posixEventLoopGroup.any().future().get() }
     }
-    
-    func testFuture() throws {
-        try XCTAssertEqual(self.group.future(1).wait(), 1)
-        try XCTAssertEqual(self.eventLoop.future(1).wait(), 1)
-        
-        try XCTAssertEqual(self.group.future(true).wait(), true)
-        try XCTAssertEqual(self.eventLoop.future("foo").wait(), "foo")
+
+    @Test
+    func future() async throws {
+        #expect(try await NIOSingletons.posixEventLoopGroup.future(1).get() == 1)
+        #expect(try await NIOSingletons.posixEventLoopGroup.any().future(1).get() == 1)
+
+        #expect(try await NIOSingletons.posixEventLoopGroup.future(true).get() == true)
+        #expect(try await NIOSingletons.posixEventLoopGroup.any().future("foo").get() == "foo")
     }
-    
-    func testFutureError() throws {
-        let groupErr: EventLoopFuture<Int> = self.group.future(error: TestError.notEqualTo1)
-        let eventLoopErr: EventLoopFuture<String> = self.eventLoop.future(error: TestError.notEqualToBar)
-        
-        try XCTAssertThrowsError(groupErr.wait())
-        try XCTAssertThrowsError(eventLoopErr.wait())
+
+    @Test
+    func futureError() async throws {
+        let groupErr: EventLoopFuture<Int> = NIOSingletons.posixEventLoopGroup.future(error: TestError.notEqualTo1)
+        let eventLoopErr: EventLoopFuture<String> = NIOSingletons.posixEventLoopGroup.any().future(error: TestError.notEqualToBar)
+
+        await #expect(throws: (any Error).self) { try await groupErr.get() }
+        await #expect(throws: (any Error).self) { try await eventLoopErr.get() }
     }
 }

--- a/Tests/AsyncKitTests/Future+CollectionTests.swift
+++ b/Tests/AsyncKitTests/Future+CollectionTests.swift
@@ -1,7 +1,7 @@
 import AsyncKit
-import XCTest
-import NIOCore
 import NIOConcurrencyHelpers
+import NIOCore
+import Testing
 
 extension EventLoopGroup {
     func spinAll(on eventLoop: any EventLoop) -> EventLoopFuture<Void> {
@@ -11,41 +11,47 @@ extension EventLoopGroup {
     }
 }
 
-final class FutureCollectionTests: AsyncKitTestCase {
-    func testMapEach() throws {
-        let collection1 = self.eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
+struct FutureCollectionTests {
+    @Test
+    func mapEach() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let collection1 = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
         let times2 = collection1.mapEach { int -> Int in int * 2 }
         
-        try XCTAssertEqual(times2.wait(), [2, 4, 6, 8, 10, 12, 14, 16, 18])
+        #expect(try await times2.get() == [2, 4, 6, 8, 10, 12, 14, 16, 18])
         
-        let collection2 = self.eventLoop.makeSucceededFuture(["a", "bb", "ccc", "dddd", "eeeee"])
+        let collection2 = eventLoop.makeSucceededFuture(["a", "bb", "ccc", "dddd", "eeeee"])
         let lengths = collection2.mapEach(\.count)
         
-        try XCTAssertEqual(lengths.wait(), [1, 2, 3, 4, 5])
+        #expect(try await lengths.get() == [1, 2, 3, 4, 5])
     
     }
     
-    func testMapEachCompact() throws {
-        let collection1 = self.eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
+    @Test
+    func mapEachCompact() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let collection1 = eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
         let times2 = collection1.mapEachCompact(Int.init)
         
-        try XCTAssertEqual(times2.wait(), [2, 3, 4, 7])
+        #expect(try await times2.get() == [2, 3, 4, 7])
         
-        let collection2 = self.eventLoop.makeSucceededFuture(["asdf", "qwer", "zxcv", ""])
+        let collection2 = eventLoop.makeSucceededFuture(["asdf", "qwer", "zxcv", ""])
         let letters = collection2.mapEachCompact(\.first)
-        try XCTAssertEqual(letters.wait(), ["a", "q", "z"])
+        #expect(try await letters.get() == ["a", "q", "z"])
     }
     
-    func testMapEachFlat() throws {
-        let collection1 = self.eventLoop.makeSucceededFuture([[1, 2, 3], [9, 8, 7], [], [0]])
+    @Test
+    func mapEachFlat() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let collection1 = eventLoop.makeSucceededFuture([[1, 2, 3], [9, 8, 7], [], [0]])
         let flat1 = collection1.mapEachFlat { $0 }
         
-        try XCTAssertEqual(flat1.wait(), [1, 2, 3, 9, 8, 7, 0])
+        #expect(try await flat1.get() == [1, 2, 3, 9, 8, 7, 0])
 
-        let collection2 = self.eventLoop.makeSucceededFuture(["ABC", "123", "👩‍👩‍👧‍👧"])
+        let collection2 = eventLoop.makeSucceededFuture(["ABC", "123", "👩‍👩‍👧‍👧"])
         let flat2 = collection2.mapEachFlat(\.utf8CString).mapEach(UInt8.init)
         
-        try XCTAssertEqual(flat2.wait(), [
+        #expect(try await flat2.get() == [
             0x41, 0x42, 0x43, 0x00, 0x31, 0x32, 0x33, 0x00, 0xf0, 0x9f, 0x91, 0xa9,
             0xe2, 0x80, 0x8d, 0xf0, 0x9f, 0x91, 0xa9, 0xe2, 0x80, 0x8d, 0xf0, 0x9f,
             0x91, 0xa7, 0xe2, 0x80, 0x8d, 0xf0, 0x9f, 0x91, 0xa7, 0x00
@@ -53,50 +59,58 @@ final class FutureCollectionTests: AsyncKitTestCase {
 
     }
     
-    func testFlatMapEach() throws {
+    @Test
+    func flatMapEach() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
-        let times2 = collection.flatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Int> in
-            return self.eventLoop.makeSucceededFuture(int * 2)
+        let times2 = collection.flatMapEach(on: eventLoop) { int -> EventLoopFuture<Int> in
+            return eventLoop.makeSucceededFuture(int * 2)
         }
         
-        try XCTAssertEqual(times2.wait(), [2, 4, 6, 8, 10, 12, 14, 16, 18])
+        #expect(try await times2.get() == [2, 4, 6, 8, 10, 12, 14, 16, 18])
     }
 
-    func testFlatMapEachVoid() throws {
-        let expectation = XCTestExpectation(description: "futures all succeeded")
-        expectation.assertForOverFulfill = true
-        expectation.expectedFulfillmentCount = 9
-        
-        let collection = self.eventLoop.makeSucceededFuture(1 ... 9)
-        let nothing = collection.flatMapEach(on: self.eventLoop) { _ in expectation.fulfill(); return self.eventLoop.makeSucceededVoidFuture() }
-        
-        _ = try nothing.wait()
-        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 10.0), .completed)
+    @Test
+    func flatMapEachVoid() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+
+        try await confirmation("futures all succeeded", expectedCount: 9) { confirm in
+            let collection = eventLoop.makeSucceededFuture(1 ... 9)
+            let nothing = collection.flatMapEach(on: eventLoop) { _ in confirm(); return eventLoop.makeSucceededVoidFuture() }
+
+            try await nothing.get()
+        }
     }
     
-    func testFlatMapEachCompact() throws {
-        let collection = self.eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
-        let times2 = collection.flatMapEachCompact(on: self.eventLoop) { int -> EventLoopFuture<Int?> in
-            return self.eventLoop.makeSucceededFuture(Int(int))
+    @Test
+    func flatMapEachCompact() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let collection = eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
+        let times2 = collection.flatMapEachCompact(on: eventLoop) { int -> EventLoopFuture<Int?> in
+            return eventLoop.makeSucceededFuture(Int(int))
         }
         
-        try XCTAssertEqual(times2.wait(), [2, 3, 4, 7])
+        #expect(try await times2.get() == [2, 3, 4, 7])
     }
     
-    func testFlatMapEachThrowing() throws {
+    @Test
+    func flatMapEachThrowing() async throws {
         struct SillyRangeError: Error {}
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
         let times2 = collection.flatMapEachThrowing { int -> Int in
             guard int < 8 else { throw SillyRangeError() }
             return int * 2
         }
         
-        XCTAssertThrowsError(try times2.wait())
+        await #expect(throws: (any Error).self) { try await times2.get() }
     }
     
-    func testFlatMapEachCompactThrowing() throws {
+    @Test
+    func flatMapEachCompactThrowing() async throws {
         struct SillyRangeError: Error {}
-        let collection = self.eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let collection = eventLoop.makeSucceededFuture(["one", "2", "3", "4", "five", "^", "7"])
         let times2 = collection.flatMapEachCompactThrowing { str -> Int? in Int(str) }
         let times2Badly = collection.flatMapEachCompactThrowing { str -> Int? in
             guard let result = Int(str) else { return nil }
@@ -104,99 +118,111 @@ final class FutureCollectionTests: AsyncKitTestCase {
             return result
         }
         
-        try XCTAssertEqual(times2.wait(), [2, 3, 4, 7])
-        XCTAssertThrowsError(try times2Badly.wait())
+        #expect(try await times2.get() == [2, 3, 4, 7])
+        await #expect(throws: (any Error).self) { try await times2Badly.get() }
     }
     
-    func testSequencedFlatMapEach() throws {
+    @Test
+    func sequencedFlatMapEach() async throws {
         struct SillyRangeError: Error {}
         var value = 0
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let lock = NIOLock()
         let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
         let times2 = collection.sequencedFlatMapEach { int -> EventLoopFuture<Int> in
             lock.withLock { value = Swift.max(value, int) }
-            guard int < 5 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
-            return self.eventLoop.makeSucceededFuture(int * 2)
+            guard int < 5 else { return NIOSingletons.posixEventLoopGroup.spinAll(on: eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            return eventLoop.makeSucceededFuture(int * 2)
         }
         
-        XCTAssertThrowsError(try times2.wait())
-        XCTAssertLessThan(lock.withLock { value }, 6)
+        await #expect(throws: (any Error).self) { try await times2.get() }
+        #expect(lock.withLock { value } < 6)
     }
 
-    func testSequencedFlatMapVoid() throws {
+    @Test
+    func sequencedFlatMapVoid() async throws {
         struct SillyRangeError: Error {}
         var value = 0
         let lock = NIOLock()
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let collection = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6, 7, 8, 9])
         let times2 = collection.sequencedFlatMapEach { int -> EventLoopFuture<Void> in
             lock.withLock { value = Swift.max(value, int) }
-            guard int < 5 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
-            return self.eventLoop.makeSucceededFuture(())
+            guard int < 5 else { return NIOSingletons.posixEventLoopGroup.spinAll(on: eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            return eventLoop.makeSucceededFuture(())
         }
         
-        XCTAssertThrowsError(try times2.wait())
-        XCTAssertLessThan(lock.withLock { value }, 6)
+        await #expect(throws: (any Error).self) { try await times2.get() }
+        #expect(lock.withLock { value } < 6)
     }
 
-    func testSequencedFlatMapEachCompact() throws {
+    @Test
+    func sequencedFlatMapEachCompact() async throws {
         struct SillyRangeError: Error {}
         var last = ""
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let lock = NIOLock()
-        let collection = self.eventLoop.makeSucceededFuture(["one", "2", "3", "not", "4", "1", "five", "^", "7"])
+        let collection = eventLoop.makeSucceededFuture(["one", "2", "3", "not", "4", "1", "five", "^", "7"])
         let times2 = collection.sequencedFlatMapEachCompact { val -> EventLoopFuture<Int?> in
-            guard let int = Int(val) else { return self.eventLoop.makeSucceededFuture(nil) }
-            guard int < 4 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            guard let int = Int(val) else { return eventLoop.makeSucceededFuture(nil) }
+            guard int < 4 else { return NIOSingletons.posixEventLoopGroup.spinAll(on: eventLoop).flatMapThrowing { throw SillyRangeError() } }
             lock.withLock { last = val }
-            return self.eventLoop.makeSucceededFuture(int * 2)
+            return eventLoop.makeSucceededFuture(int * 2)
         }
         
-        XCTAssertThrowsError(try times2.wait())
-        XCTAssertEqual(lock.withLock { last }, "3")
+        await #expect(throws: (any Error).self) { try await times2.get() }
+        #expect(lock.withLock { last } == "3")
     }
 
-    func testELSequencedFlatMapEach() throws {
+    @Test
+    func elSequencedFlatMapEach() async throws {
         struct SillyRangeError: Error {}
         var value = 0
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let lock = NIOLock()
         let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        let times2 = collection.sequencedFlatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Int> in
+        let times2 = collection.sequencedFlatMapEach(on: eventLoop) { int -> EventLoopFuture<Int> in
             lock.withLock { value = Swift.max(value, int) }
-            guard int < 5 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
-            return self.eventLoop.makeSucceededFuture(int * 2)
+            guard int < 5 else { return NIOSingletons.posixEventLoopGroup.spinAll(on: eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            return eventLoop.makeSucceededFuture(int * 2)
         }
         
-        XCTAssertThrowsError(try times2.wait())
-        XCTAssertLessThan(lock.withLock { value }, 6)
+        await #expect(throws: (any Error).self) { try await times2.get() }
+        #expect(lock.withLock { value } < 6)
     }
 
-    func testELSequencedFlatMapVoid() throws {
+    @Test
+    func elSequencedFlatMapVoid() async throws {
         struct SillyRangeError: Error {}
         var value = 0
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let lock = NIOLock()
         let collection = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        let times2 = collection.sequencedFlatMapEach(on: self.eventLoop) { int -> EventLoopFuture<Void> in
+        let times2 = collection.sequencedFlatMapEach(on: eventLoop) { int -> EventLoopFuture<Void> in
             lock.withLock { value = Swift.max(value, int) }
-            guard int < 5 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
-            return self.eventLoop.makeSucceededFuture(())
+            guard int < 5 else { return NIOSingletons.posixEventLoopGroup.spinAll(on: eventLoop).flatMapThrowing { throw SillyRangeError() } }
+            return eventLoop.makeSucceededFuture(())
         }
         
-        XCTAssertThrowsError(try times2.wait())
-        XCTAssertLessThan(lock.withLock { value }, 6)
+        await #expect(throws: (any Error).self) { try await times2.get() }
+        #expect(lock.withLock { value } < 6)
     }
 
-    func testELSequencedFlatMapEachCompact() throws {
+    @Test
+    func elSequencedFlatMapEachCompact() async throws {
         struct SillyRangeError: Error {}
         var last = ""
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let lock = NIOLock()
         let collection = ["one", "2", "3", "not", "4", "1", "five", "^", "7"]
-        let times2 = collection.sequencedFlatMapEachCompact(on: self.eventLoop) { val -> EventLoopFuture<Int?> in
-            guard let int = Int(val) else { return self.eventLoop.makeSucceededFuture(nil) }
-            guard int < 4 else { return self.group.spinAll(on: self.eventLoop).flatMapThrowing { throw SillyRangeError() } }
+        let times2 = collection.sequencedFlatMapEachCompact(on: eventLoop) { val -> EventLoopFuture<Int?> in
+            guard let int = Int(val) else { return eventLoop.makeSucceededFuture(nil) }
+            guard int < 4 else { return NIOSingletons.posixEventLoopGroup.spinAll(on: eventLoop).flatMapThrowing { throw SillyRangeError() } }
             lock.withLock { last = val }
-            return self.eventLoop.makeSucceededFuture(int * 2)
+            return eventLoop.makeSucceededFuture(int * 2)
         }
         
-        XCTAssertThrowsError(try times2.wait())
-        XCTAssertEqual(lock.withLock { last }, "3")
+        await #expect(throws: (any Error).self) { try await times2.get() }
+        #expect(lock.withLock { last } == "3")
     }
 }

--- a/Tests/AsyncKitTests/Future+ConjunctionTests.swift
+++ b/Tests/AsyncKitTests/Future+ConjunctionTests.swift
@@ -1,191 +1,194 @@
 import AsyncKit
-import XCTest
 import NIOCore
+import Testing
 
-final class FutureConjunctionTests: AsyncKitTestCase {
-    func testTrivialStrictMapCorrectness() throws {
-        XCTAssertNotNil(strictMap(()) { $0 })
-        XCTAssertNil(strictMap(Void?.none) { _ in () })
+@Suite
+struct FutureConjunctionTests {
+    @Test
+    func trivialStrictMapCorrectness() {
+        #expect(strictMap(()) { $0 } != nil)
+        #expect(strictMap(Void?.none) { _ in () } == nil)
         
-        XCTAssertNotNil(strictMap((), ()) { $1 })
-        XCTAssertNil(strictMap(Void?.none, ()) { $1 })
-        XCTAssertNil(strictMap((), Void?.none) { $1 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none) { $1 })
+        #expect(strictMap((), ()) { $1 } != nil)
+        #expect(strictMap(Void?.none, ()) { $1 } == nil)
+        #expect(strictMap((), Void?.none) { $1 } == nil)
+        #expect(strictMap(Void?.none, Void?.none) { $1 } == nil)
 
-        XCTAssertNotNil(strictMap((), (), ()) { $2 })
-        XCTAssertNil(strictMap(Void?.none, (), ()) { $2 })
-        XCTAssertNil(strictMap((), Void?.none, ()) { $2 })
-        XCTAssertNil(strictMap((), (), Void?.none) { $2 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, ()) { $2 })
-        XCTAssertNil(strictMap(Void?.none, (), Void?.none) { $2 })
-        XCTAssertNil(strictMap((), Void?.none, Void?.none) { $2 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none) { $2 })
+        #expect(strictMap((), (), ()) { $2 } != nil)
+        #expect(strictMap(Void?.none, (), ()) { $2 } == nil)
+        #expect(strictMap((), Void?.none, ()) { $2 } == nil)
+        #expect(strictMap((), (), Void?.none) { $2 } == nil)
+        #expect(strictMap(Void?.none, Void?.none, ()) { $2 } == nil)
+        #expect(strictMap(Void?.none, (), Void?.none) { $2 } == nil)
+        #expect(strictMap((), Void?.none, Void?.none) { $2 } == nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none) { $2 } == nil)
 
-        XCTAssertNotNil(strictMap((), (), (), ()) { $3 })
-        XCTAssertNil(strictMap(Void?.none, (), (), ()) { $3 })
-        XCTAssertNil(strictMap((), Void?.none, (), ()) { $3 })
-        XCTAssertNil(strictMap((), (), Void?.none, ()) { $3 })
-        XCTAssertNil(strictMap((), (), (), Void?.none) { $3 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, (), ()) { $3 })
-        XCTAssertNil(strictMap(Void?.none, (), Void?.none, ()) { $3 })
-        XCTAssertNil(strictMap(Void?.none, (), (), Void?.none) { $3 })
-        XCTAssertNil(strictMap((), Void?.none, Void?.none, ()) { $3 })
-        XCTAssertNil(strictMap((), Void?.none, (), Void?.none) { $3 })
-        XCTAssertNil(strictMap((), (), Void?.none, Void?.none) { $3 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, ()) { $3 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, (), Void?.none) { $3 })
-        XCTAssertNil(strictMap(Void?.none, (), Void?.none, Void?.none) { $3 })
-        XCTAssertNil(strictMap((), Void?.none, Void?.none, Void?.none) { $3 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none) { $3 })
+        #expect(strictMap((), (), (), ()) { $3 } != nil)
+        #expect(strictMap(Void?.none, (), (), ()) { $3 } == nil)
+        #expect(strictMap((), Void?.none, (), ()) { $3 } == nil)
+        #expect(strictMap((), (), Void?.none, ()) { $3 } == nil)
+        #expect(strictMap((), (), (), Void?.none) { $3 } == nil)
+        #expect(strictMap(Void?.none, Void?.none, (), ()) { $3 } == nil)
+        #expect(strictMap(Void?.none, (), Void?.none, ()) { $3 } == nil)
+        #expect(strictMap(Void?.none, (), (), Void?.none) { $3 } == nil)
+        #expect(strictMap((), Void?.none, Void?.none, ()) { $3 } == nil)
+        #expect(strictMap((), Void?.none, (), Void?.none) { $3 } == nil)
+        #expect(strictMap((), (), Void?.none, Void?.none) { $3 } == nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, ()) { $3 } == nil)
+        #expect(strictMap(Void?.none, Void?.none, (), Void?.none) { $3 } == nil)
+        #expect(strictMap(Void?.none, (), Void?.none, Void?.none) { $3 } == nil)
+        #expect(strictMap((), Void?.none, Void?.none, Void?.none) { $3 } == nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none) { $3 } == nil)
 
         // The full test set gets absurd after more or less this point so just do the minimums to satisfy test coverage
-        XCTAssertNotNil(strictMap((), (), (), (), ()) { $4 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $4 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), ()) { $5 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $5 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), ()) { $6 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $6 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), ()) { $7 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $7 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), ()) { $8 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $8 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), ()) { $9 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $9 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), ()) { $10 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $10 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), ()) { $11 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $11 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), ()) { $12 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $12 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $13 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $13 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $14 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $14 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $15 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $15 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $16 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $16 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $17 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $17 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $18 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $18 })
-        XCTAssertNotNil(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $19 })
-        XCTAssertNil(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $19 })
+        #expect(strictMap((), (), (), (), ()) { $4 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $4 } == nil)
+        #expect(strictMap((), (), (), (), (), ()) { $5 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $5 } == nil)
+        #expect(strictMap((), (), (), (), (), (), ()) { $6 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $6 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), ()) { $7 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $7 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), ()) { $8 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $8 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), ()) { $9 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $9 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), ()) { $10 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $10 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), ()) { $11 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $11 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), ()) { $12 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $12 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $13 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $13 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $14 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $14 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $15 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $15 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $16 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $16 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $17 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $17 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $18 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $18 } == nil)
+        #expect(strictMap((), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()) { $19 } != nil)
+        #expect(strictMap(Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none, Void?.none) { $19 } == nil)
     }
-    
-    func testTrivialWhenTheySucceedCorectness() throws {
-        let el1 = self.group.any()
-        let el2 = self.group.any()
+
+    @Test
+    func trivialWhenTheySucceedCorectness() async throws {
+        let el1 = NIOSingletons.posixEventLoopGroup.any()
+        let el2 = NIOSingletons.posixEventLoopGroup.any()
         
         let f1 = el1.submit { return "string value" }
         let f2 = el1.submit { return Int.min }
         let f3 = el2.submit { return true }
         
-        let result = try EventLoopFuture.whenTheySucceed(f1, f2, f3).wait()
-        
-        XCTAssertEqual(result.0, "string value")
-        XCTAssertEqual(result.1, Int.min)
-        XCTAssertEqual(result.2, true)
+        let result = try await EventLoopFuture.whenTheySucceed(f1, f2, f3).get()
+
+        #expect(result.0 == "string value")
+        #expect(result.1 == Int.min)
+        #expect(result.2 == true)
     }
     
-    func testInvokingAllVariantsOfWhenTheySucceed() throws {
+    func testInvokingAllVariantsOfWhenTheySucceed() async throws {
         // Yes, this test is using futures that are all the same type and thus could be passed to
         // `whenAllSucceed()` instead of `whenTheySucceed()`. Doesn't matter - the point in this
         // test is to cover all the variants for minimum correctness, not test full functionality.
         do {
-            let f = (0 ..< 2).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1)
+            let f = (0 ..< 2).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1]).get()
+            #expect(r.0 == 0 && r.1 == 1)
         }
         do {
-            let f = (0 ..< 3).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2)
+            let f = (0 ..< 3).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2)
         }
         do {
-            let f = (0 ..< 4).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3)
+            let f = (0 ..< 4).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3)
         }
         do {
-            let f = (0 ..< 5).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4)
+            let f = (0 ..< 5).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4)
         }
         do {
-            let f = (0 ..< 6).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5)
+            let f = (0 ..< 6).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5)
         }
         do {
-            let f = (0 ..< 7).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6)
+            let f = (0 ..< 7).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6)
         }
         do {
-            let f = (0 ..< 8).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7)
+            let f = (0 ..< 8).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7)
         }
         do {
-            let f = (0 ..< 9).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8)
+            let f = (0 ..< 9).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8)
         }
         do {
-            let f = (0 ..< 10).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9)
+            let f = (0 ..< 10).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9)
         }
         do {
-            let f = (0 ..< 11).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10)
+            let f = (0 ..< 11).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10)
         }
         do {
-            let f = (0 ..< 12).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11)
+            let f = (0 ..< 12).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11)
         }
         do {
-            let f = (0 ..< 13).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12)
+            let f = (0 ..< 13).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12)
         }
         do {
-            let f = (0 ..< 14).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13)
+            let f = (0 ..< 14).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13)
         }
         do {
-            let f = (0 ..< 15).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14)
+            let f = (0 ..< 15).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14)
         }
         do {
-            let f = (0 ..< 16).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15)
+            let f = (0 ..< 16).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15)
         }
         do {
-            let f = (0 ..< 17).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16)
+            let f = (0 ..< 17).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16)
         }
         do {
-            let f = (0 ..< 18).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16 && r.17 == 17)
+            let f = (0 ..< 18).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16 && r.17 == 17)
         }
         do {
-            let f = (0 ..< 19).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17], f[18]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16 && r.17 == 17 && r.18 == 18)
+            let f = (0 ..< 19).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17], f[18]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16 && r.17 == 17 && r.18 == 18)
         }
         do {
-            let f = (0 ..< 20).map { n in self.eventLoop.submit { n } }
-            let r = try EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17], f[18], f[19]).wait()
-            XCTAssert(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16 && r.17 == 17 && r.18 == 18 && r.19 == 19)
+            let f = (0 ..< 20).map { n in NIOSingletons.posixEventLoopGroup.any().submit { n } }
+            let r = try await EventLoopFuture.whenTheySucceed(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7], f[8], f[9], f[10], f[11], f[12], f[13], f[14], f[15], f[16], f[17], f[18], f[19]).get()
+            #expect(r.0 == 0 && r.1 == 1 && r.2 == 2 && r.3 == 3 && r.4 == 4 && r.5 == 5 && r.6 == 6 && r.7 == 7 && r.8 == 8 && r.9 == 9 && r.10 == 10 && r.11 == 11 && r.12 == 12 && r.13 == 13 && r.14 == 14 && r.15 == 15 && r.16 == 16 && r.17 == 17 && r.18 == 18 && r.19 == 19)
         }
     }
 }

--- a/Tests/AsyncKitTests/Future+MiscellaneousTests.swift
+++ b/Tests/AsyncKitTests/Future+MiscellaneousTests.swift
@@ -1,32 +1,38 @@
-import XCTest
 import AsyncKit
+import class Foundation.Thread
 import NIOCore
+import Testing
 
-final class FutureMiscellaneousTests: AsyncKitTestCase {
-    func testGuard() {
+@Suite
+struct FutureMiscellaneousTests {
+    @Test
+    func `guard`() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future1 = eventLoop.makeSucceededFuture(1)
         let guardedFuture1 = future1.guard({ $0 == 1 }, else: TestError.notEqualTo1)
-        XCTAssertNoThrow(try guardedFuture1.wait())
-        
+        await #expect(throws: Never.self) { try await guardedFuture1.get() }
+
         let future2 = eventLoop.makeSucceededFuture("foo")
         let guardedFuture2 = future2.guard({ $0 == "bar" }, else: TestError.notEqualToBar)
-        XCTAssertThrowsError(try guardedFuture2.wait())
+        await #expect(throws: (any Error).self) { try await guardedFuture2.get() }
     }
-    
-    func testTryThrowing() {
+
+    @Test
+    func tryThrowing() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future1: EventLoopFuture<String> = eventLoop.tryFuture { return "Hello" }
         let future2: EventLoopFuture<String> = eventLoop.tryFuture { throw TestError.notEqualTo1 }
-        var value: String = ""
-        
-        try XCTAssertNoThrow(value = future1.wait())
-        XCTAssertEqual(value, "Hello")
-        try XCTAssertThrowsError(future2.wait())
+
+        #expect(try await future1.get() == "Hello")
+        await #expect(throws: (any Error).self) { try await future2.get() }
     }
 
-    func testTryFutureThread() throws {
-        let future = self.eventLoop.tryFuture { Thread.current.name }
-        let name = try XCTUnwrap(future.wait())
+    @Test
+    func tryFutureThread() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let future = eventLoop.tryFuture { Thread.current.name }
+        let name = try #require(try await future.get())
 
-        XCTAssert(name.starts(with: "NIO-ELT"), "'\(name)' is not a valid NIO ELT name")
+        #expect(name.starts(with: "NIO-SGL"), "'\(name)' is not a valid NIO ELT name")
     }
 }

--- a/Tests/AsyncKitTests/Future+NonemptyTests.swift
+++ b/Tests/AsyncKitTests/Future+NonemptyTests.swift
@@ -1,31 +1,35 @@
-import XCTest
 import AsyncKit
 import NIOCore
+import Testing
 
-final class FutureNonemptyTests: AsyncKitTestCase {
-    func testNonempty() {
-        try XCTAssertNoThrow(self.eventLoop.future([0]).nonempty(orError: TestError.notEqualTo1).wait())
-        try XCTAssertThrowsError(self.eventLoop.future([]).nonempty(orError: TestError.notEqualTo1).wait())
-        
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyMap(or: 1, { $0[0] }).wait(), 0)
-        XCTAssertEqual(try self.eventLoop.future([]).nonemptyMap(or: 1, { $0[0] }).wait(), 1)
+@Suite
+struct FutureNonemptyTests {
+    @Test
+    func nonempty() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
 
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyMap({ [$0[0]] }).wait(), [0])
-        XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyMap({ [$0[0]] }).wait(), [])
+        await #expect(throws: Never.self) { try await eventLoop.future([0]).nonempty(orError: TestError.notEqualTo1).get() }
+        await #expect(throws: (any Error).self) { try await eventLoop.future([]).nonempty(orError: TestError.notEqualTo1).get() }
 
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMapThrowing(or: 1, { (a) throws -> Int in a[0] }).wait(), 0)
-        XCTAssertEqual(try self.eventLoop.future([]).nonemptyFlatMapThrowing(or: 1, { (a) throws -> Int in a[0] }).wait(), 1)
+        #expect(try await eventLoop.future([0]).nonemptyMap(or: 1, { $0[0] }).get() == 0)
+        #expect(try await eventLoop.future([]).nonemptyMap(or: 1, { $0[0] }).get() == 1)
 
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).wait(), [0])
-        XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).wait(), [])
+        #expect(try await eventLoop.future([0]).nonemptyMap({ [$0[0]] }).get() == [0])
+        #expect(try await eventLoop.future([Int]()).nonemptyMap({ [$0[0]] }).get() == [])
 
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMap(or: 1, { self.eventLoop.future($0[0]) }).wait(), 0)
-        XCTAssertEqual(try self.eventLoop.future([]).nonemptyFlatMap(or: 1, { self.eventLoop.future($0[0]) }).wait(), 1)
+        #expect(try await eventLoop.future([0]).nonemptyFlatMapThrowing(or: 1, { (a) throws -> Int in a[0] }).get() == 0)
+        #expect(try await eventLoop.future([]).nonemptyFlatMapThrowing(or: 1, { (a) throws -> Int in a[0] }).get() == 1)
 
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMap(orFlat: self.eventLoop.future(1), { self.eventLoop.future($0[0]) }).wait(), 0)
-        XCTAssertEqual(try self.eventLoop.future([]).nonemptyFlatMap(orFlat: self.eventLoop.future(1), { self.eventLoop.future($0[0]) }).wait(), 1)
+        #expect(try await eventLoop.future([0]).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).get() == [0])
+        #expect(try await eventLoop.future([Int]()).nonemptyFlatMapThrowing({ (a) throws -> [Int] in [a[0]] }).get() == [])
 
-        XCTAssertEqual(try self.eventLoop.future([0]).nonemptyFlatMap({ self.eventLoop.future([$0[0]]) }).wait(), [0])
-        XCTAssertEqual(try self.eventLoop.future([Int]()).nonemptyFlatMap({ self.eventLoop.future([$0[0]]) }).wait(), [])
+        #expect(try await eventLoop.future([0]).nonemptyFlatMap(or: 1, { eventLoop.future($0[0]) }).get() == 0)
+        #expect(try await eventLoop.future([]).nonemptyFlatMap(or: 1, { eventLoop.future($0[0]) }).get() == 1)
+
+        #expect(try await eventLoop.future([0]).nonemptyFlatMap(orFlat: eventLoop.future(1), { eventLoop.future($0[0]) }).get() == 0)
+        #expect(try await eventLoop.future([]).nonemptyFlatMap(orFlat: eventLoop.future(1), { eventLoop.future($0[0]) }).get() == 1)
+
+        #expect(try await eventLoop.future([0]).nonemptyFlatMap({ eventLoop.future([$0[0]]) }).get() == [0])
+        #expect(try await eventLoop.future([Int]()).nonemptyFlatMap({ eventLoop.future([$0[0]]) }).get() == [])
     }
 }

--- a/Tests/AsyncKitTests/Future+OptionalTests.swift
+++ b/Tests/AsyncKitTests/Future+OptionalTests.swift
@@ -1,56 +1,63 @@
 import AsyncKit
-import XCTest
 import NIOCore
+import Testing
 
-final class FutureOptionalTests: AsyncKitTestCase {
-    func testOptionalMap() throws {
-        let future = self.eventLoop.makeSucceededFuture(Optional<Int>.some(1))
-        let null = self.eventLoop.makeSucceededFuture(Optional<Int>.none)
+@Suite
+struct FutureOptionalTests {
+    @Test
+    func optionalMap() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let future = eventLoop.makeSucceededFuture(Optional<Int>.some(1))
+        let null = eventLoop.makeSucceededFuture(Optional<Int>.none)
         
         let times2 = future.optionalMap { $0 * 2 }
         let null2 = null.optionalMap { $0 * 2 }
         let nullResult = future.optionalMap { _ in Optional<Int>.none }
         
-        try XCTAssertEqual(2, times2.wait())
-        try XCTAssertEqual(nil, null2.wait())
-        try XCTAssertEqual(nil, nullResult.wait())
+        #expect(try await 2 == times2.get())
+        #expect(try await nil == null2.get())
+        #expect(try await nil == nullResult.get())
     }
     
-    func testOptionalFlatMapThrowing() throws {
-        let future = self.eventLoop.makeSucceededFuture(Optional<Int>.some(1))
+    @Test
+    func optionalFlatMapThrowing() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let future = eventLoop.makeSucceededFuture(Optional<Int>.some(1))
         
         let times2 = future.optionalFlatMapThrowing { $0 * 2 }
         let null2 = future.optionalFlatMapThrowing { return $0 % 2 == 0 ? $0 : nil }
         let error = future.optionalFlatMapThrowing { _ in throw TestError.generic }
         
-        try XCTAssertEqual(2, times2.wait())
-        try XCTAssertEqual(nil, null2.wait())
-        try XCTAssertThrowsError(error.wait())
+        #expect(try await 2 == times2.get())
+        #expect(try await nil == null2.get())
+        await #expect(throws: (any Error).self) { try await error.get() }
     }
     
-    func testOptionalFlatMap() throws {
-        let future = self.eventLoop.makeSucceededFuture(Optional<Int>.some(1))
-        let null = self.eventLoop.makeSucceededFuture(Optional<Int>.none)
+    @Test
+    func optionalFlatMap() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
+        let future = eventLoop.makeSucceededFuture(Optional<Int>.some(1))
+        let null = eventLoop.makeSucceededFuture(Optional<Int>.none)
         
         var times2 = future.optionalFlatMap { self.multiply($0, 2) }
         var null2 = null.optionalFlatMap { self.multiply($0, 2) }
         
-        try XCTAssertEqual(2, times2.wait())
-        try XCTAssertEqual(nil, null2.wait())
+        #expect(try await 2 == times2.get())
+        #expect(try await nil == null2.get())
 
         
         times2 = future.optionalFlatMap { self.multiply($0, Optional<Int>.some(2)) }
         null2 = future.optionalFlatMap { self.multiply($0, nil) }
         
-        try XCTAssertEqual(2, times2.wait())
-        try XCTAssertEqual(nil, null2.wait())
+        #expect(try await 2 == times2.get())
+        #expect(try await nil == null2.get())
     }
     
     func multiply(_ a: Int, _ b: Int) -> EventLoopFuture<Int> {
-        return self.group.any().makeSucceededFuture(a * b)
+        return NIOSingletons.posixEventLoopGroup.any().makeSucceededFuture(a * b)
     }
     
     func multiply(_ a: Int, _ b: Int?) -> EventLoopFuture<Int?> {
-        return self.group.any().makeSucceededFuture(b == nil ? nil : a * b!)
+        return NIOSingletons.posixEventLoopGroup.any().makeSucceededFuture(b == nil ? nil : a * b!)
     }
 }

--- a/Tests/AsyncKitTests/Future+TransformTests.swift
+++ b/Tests/AsyncKitTests/Future+TransformTests.swift
@@ -1,22 +1,25 @@
-import XCTest
 import AsyncKit
 import NIOCore
+import Testing
 
-class FutureTransformTests: AsyncKitTestCase {
-    func testTransforms() throws {
+@Suite
+struct FutureTransformTests {
+    @Test
+    func transforms() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future = eventLoop.makeSucceededFuture(Int.random(in: 0...100))
         
-        XCTAssert(try future.transform(to: true).wait())
-        
+        #expect(try await future.transform(to: true).get())
+
         let futureA = eventLoop.makeSucceededFuture(Int.random(in: 0...100))
         let futureB = eventLoop.makeSucceededFuture(Int.random(in: 0...100))
         
-        XCTAssert(try futureA.and(futureB).transform(to: true).wait())
-        
+        #expect(try await futureA.and(futureB).transform(to: true).get())
+
         let futureBool = eventLoop.makeSucceededFuture(true)
         
-        XCTAssert(try future.transform(to: futureBool).wait())
-        
-        XCTAssert(try futureA.and(futureB).transform(to: futureBool).wait())
+        #expect(try await future.transform(to: futureBool).get())
+
+        #expect(try await futureA.and(futureB).transform(to: futureBool).get())
     }
 }

--- a/Tests/AsyncKitTests/Future+TryTests.swift
+++ b/Tests/AsyncKitTests/Future+TryTests.swift
@@ -1,42 +1,39 @@
-import NIOCore
 import AsyncKit
-import XCTest
+import NIOCore
+import Testing
 
-final class FutureTryTests: AsyncKitTestCase {
-    func testTryFlatMapPropagatesCallbackError() {
+@Suite
+struct FutureTryTests {
+    @Test
+    func tryFlatMapPropagatesCallbackError() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future = eventLoop.future(0)
             .tryFlatMap { _ -> EventLoopFuture<String> in
                 throw TestError.generic
             }
 
-        XCTAssertThrowsError(try future.wait()) { error in
-            guard case TestError.generic = error else {
-                XCTFail("Received an unexpected error: \(error)")
-                return
-            }
-        }
+        await #expect(throws: TestError.generic) { try await future.get() }
     }
 
-    func testTryFlatMapPropagatesInnerError() {
+    @Test
+    func tryFlatMapPropagatesInnerError() async {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future = eventLoop.future(0)
             .tryFlatMap { _ -> EventLoopFuture<String> in
-                self.eventLoop.makeFailedFuture(TestError.generic)
+                eventLoop.makeFailedFuture(TestError.generic)
             }
 
-        XCTAssertThrowsError(try future.wait()) { error in
-            guard case TestError.generic = error else {
-                XCTFail("Received an unexpected error: \(error)")
-                return
-            }
-        }
+        await #expect(throws: TestError.generic) { try await future.get() }
     }
 
-    func testTryFlatMapPropagatesResult() throws {
+    @Test
+    func tryFlatMapPropagatesResult() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future = eventLoop.future(0)
             .tryFlatMap { value -> EventLoopFuture<String> in
-                self.eventLoop.makeSucceededFuture(String(describing: value))
+                eventLoop.makeSucceededFuture(String(describing: value))
             }
 
-        try XCTAssertEqual("0", future.wait())
+        #expect(try await future.get() == "0")
     }
 }

--- a/Tests/AsyncKitTests/FutureOperatorsTests.swift
+++ b/Tests/AsyncKitTests/FutureOperatorsTests.swift
@@ -1,136 +1,159 @@
-import XCTest
 import AsyncKit
 import NIOCore
+import Testing
 
-final class FutureOperatorTests: AsyncKitTestCase {
-    func testAddition() throws {
+@Suite
+struct FutureOperatorTests {
+    @Test
+    func addition() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
 
-        XCTAssertEqual(try (future1 + future2).wait(), 13)
+        #expect(try await (future1 + future2).get() == 13)
         
         future1 += future2
-        XCTAssertEqual(try future1.wait(), 13)
+        #expect(try await future1.get() == 13)
         
         var arrayFuture1 = eventLoop.makeSucceededFuture([1, 2, 3])
         let arrayFuture2 = eventLoop.makeSucceededFuture([4, 5, 6])
         
-        XCTAssertEqual(try (arrayFuture1 + arrayFuture2).wait(), [1, 2, 3, 4, 5, 6])
-        XCTAssertNotEqual(try (arrayFuture1 + arrayFuture2).wait(), try (arrayFuture2 + arrayFuture1).wait())
+        #expect(try await (arrayFuture1 + arrayFuture2).get() == [1, 2, 3, 4, 5, 6])
+        #expect(try await (arrayFuture1 + arrayFuture2).get() != (arrayFuture2 + arrayFuture1).get())
         
         arrayFuture1 += arrayFuture2
-        XCTAssertEqual(try arrayFuture1.wait(), [1, 2, 3, 4, 5, 6])
+        #expect(try await arrayFuture1.get() == [1, 2, 3, 4, 5, 6])
     }
     
-    func testSubtraction() throws {
+    @Test
+    func subtraction() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssertEqual(try (future1 - future2).wait(), 3)
+        #expect(try await (future1 - future2).get() == 3)
         
         future1 -= future2
-        XCTAssertEqual(try future1.wait(), 3)
+        #expect(try await future1.get() == 3)
         
         var arrayFuture1 = eventLoop.makeSucceededFuture([1, 2, 3, 4, 5, 6])
         let arrayFuture2 = eventLoop.makeSucceededFuture([4, 5, 6])
         
-        XCTAssertEqual(try (arrayFuture1 - arrayFuture2).wait(), [1, 2, 3])
+        #expect(try await (arrayFuture1 - arrayFuture2).get() == [1, 2, 3])
         
         arrayFuture1 -= arrayFuture2
-        XCTAssertEqual(try arrayFuture1.wait(), [1, 2, 3])
+        #expect(try await arrayFuture1.get() == [1, 2, 3])
     }
     
-    func testMultiplication() throws {
+    @Test
+    func multiplication() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssertEqual(try (future1 * future2).wait(), 40)
+        #expect(try await (future1 * future2).get() == 40)
         
         future1 *= future2
-        XCTAssertEqual(try future1.wait(), 40)
+        #expect(try await future1.get() == 40)
     }
     
-    func testModulo() throws {
+    @Test
+    func modulo() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssertEqual(try (future1 % future2).wait(), 3)
+        #expect(try await (future1 % future2).get() == 3)
         
         future1 %= future2
-        XCTAssertEqual(try future1.wait(), 3)
+        #expect(try await future1.get() == 3)
     }
     
-    func testDivision() throws {
+    @Test
+    func division() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(40)
         let future2 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssertEqual(try (future1 / future2).wait(), 8)
+        #expect(try await (future1 / future2).get() == 8)
         
         future1 /= future2
-        XCTAssertEqual(try future1.wait(), 8)
+        #expect(try await future1.get() == 8)
     }
     
-    func testComparison() throws {
+    @Test
+    func comparison() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
         let future3 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssert(try (future2 < future1).wait())
-        XCTAssert(try (future2 <= future3).wait())
-        XCTAssert(try (future2 >= future3).wait())
-        XCTAssert(try (future1 > future3).wait())
+        #expect(try await (future2 < future1).get())
+        #expect(try await (future2 <= future3).get())
+        #expect(try await (future2 >= future3).get())
+        #expect(try await (future1 > future3).get())
     }
 
-    func testBitshifts() throws {
+    @Test
+    func bitshifts() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(255)
         let future2 = eventLoop.makeSucceededFuture(16)
 
-        XCTAssertEqual(try (future1 << future2).wait(), 16711680)
+        #expect(try await (future1 << future2).get() == 16711680)
         
         future1 <<= future2
-        XCTAssertEqual(try future1.wait(), 16711680)
+        #expect(try await future1.get() == 16711680)
         
         var future3 = eventLoop.makeSucceededFuture(16711680)
         let future4 = eventLoop.makeSucceededFuture(16)
         
-        XCTAssertEqual(try (future3 >> future4).wait(), 255)
+        #expect(try await (future3 >> future4).get() == 255)
         
         future3 >>= future4
-        XCTAssertEqual(try future3.wait(), 255)
+        #expect(try await future3.get() == 255)
     }
     
-    func testAND() throws {
+    @Test
+    func and() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(200)
         let future2 = eventLoop.makeSucceededFuture(500)
         
-        XCTAssertEqual(try (future1 & future2).wait(), 192)
+        #expect(try await (future1 & future2).get() == 192)
         
         future1 &= future2
-        XCTAssertEqual(try future1.wait(), 192)
+        #expect(try await future1.get() == 192)
     }
     
-    func testXOR() throws {
+    @Test
+    func xor() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssertEqual(try (future1 ^ future2).wait(), 13)
+        #expect(try await (future1 ^ future2).get() == 13)
         
         future1 ^= future2
-        XCTAssertEqual(try future1.wait(), 13)
+        #expect(try await future1.get() == 13)
     }
     
-    func testOR() throws {
+    @Test
+    func or() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)
         
-        XCTAssertEqual(try (future1 | future2).wait(), 13)
+        #expect(try await (future1 | future2).get() == 13)
         
         future1 |= future2
-        XCTAssertEqual(try future1.wait(), 13)
+        #expect(try await future1.get() == 13)
     }
     
-    func testNOT() throws {
+    @Test
+    func not() async throws {
+        let eventLoop = NIOSingletons.posixEventLoopGroup.any()
         let future1: EventLoopFuture<UInt8> = eventLoop.makeSucceededFuture(0b00001111)
-        XCTAssertEqual(try ~future1.wait(), 0b11110000)
+        #expect(try await ~future1.get() == 0b11110000)
     }
 }


### PR DESCRIPTION
**These changes are now available in [1.22.0](https://github.com/vapor/async-kit/releases/tag/1.22.0)**


Apparently `MemberImportVisibility` is acting transitively on dependencies in some scenarios again, so this fixes that issue in this package. Also bumps the Swift requirement to 6.0 and converts the tests to SwiftTesting.

Fixes #112